### PR TITLE
Feature flags

### DIFF
--- a/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
+++ b/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
@@ -17,6 +17,12 @@
     else
       true
 
+  @isAppManagementEnabled = () ->
+    if ADMIN_PANEL_CONFIG.apps_management?
+      ADMIN_PANEL_CONFIG.apps_management.enabled
+    else
+      true
+
   @isOrganizationManagementEnabled = () ->
     if ADMIN_PANEL_CONFIG.customer_management? && ADMIN_PANEL_CONFIG.customer_management.organization?
       ADMIN_PANEL_CONFIG.customer_management.organization.enabled

--- a/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
+++ b/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
@@ -1,0 +1,14 @@
+# This service is a wrapper around the config we fetch from the backend
+# TODO: service or factory?
+
+# MnoeAdminConfig.financeEnabled?
+@App.factory 'MnoeAdminConfig', ($log, ADMIN_PANEL_CONFIG) ->
+  _self = @
+
+  @isFinanceEnabled = () ->
+    if ADMIN_PANEL_CONFIG.finance?
+      ADMIN_PANEL_CONFIG.finance.enabled
+    else
+      true
+
+  return @

--- a/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
+++ b/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
@@ -5,6 +5,12 @@
 @App.factory 'MnoeAdminConfig', ($log, ADMIN_PANEL_CONFIG) ->
   _self = @
 
+  @isStaffEnabled = () ->
+    if ADMIN_PANEL_CONFIG.staff?
+      ADMIN_PANEL_CONFIG.staff.enabled
+    else
+      true
+
   @isFinanceEnabled = () ->
     if ADMIN_PANEL_CONFIG.finance?
       ADMIN_PANEL_CONFIG.finance.enabled

--- a/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
+++ b/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
@@ -5,6 +5,12 @@
 @App.factory 'MnoeAdminConfig', ($log, ADMIN_PANEL_CONFIG) ->
   _self = @
 
+  @isImpersonationEnabled = () ->
+    if ADMIN_PANEL_CONFIG.impersonation
+      not ADMIN_PANEL_CONFIG.impersonation.disabled
+    else
+      true
+
   @isStaffEnabled = () ->
     if ADMIN_PANEL_CONFIG.staff?
       ADMIN_PANEL_CONFIG.staff.enabled

--- a/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
+++ b/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
@@ -17,4 +17,16 @@
     else
       true
 
+  @isOrganizationManagementEnabled = () ->
+    if ADMIN_PANEL_CONFIG.customer_management? && ADMIN_PANEL_CONFIG.customer_management.organization?
+      ADMIN_PANEL_CONFIG.customer_management.organization.enabled
+    else
+      true
+
+  @isUserManagementEnabled = () ->
+    if ADMIN_PANEL_CONFIG.customer_management? && ADMIN_PANEL_CONFIG.customer_management.user?
+      ADMIN_PANEL_CONFIG.customer_management.user.enabled
+    else
+      true
+
   return @

--- a/src/app/components/mnoe-users-local-list/mnoe-users-local-list.coffee
+++ b/src/app/components/mnoe-users-local-list/mnoe-users-local-list.coffee
@@ -1,7 +1,7 @@
 #
 # Mnoe Users List
 #
-@App.directive('mnoeUsersLocalList', ($window, $filter, $log, toastr, MnoeUsers, MnoErrorsHandler) ->
+@App.directive('mnoeUsersLocalList', ($window, $filter, $log, toastr, MnoeAdminConfig, MnoeUsers, MnoErrorsHandler) ->
   restrict: 'E'
   scope: {
     list: '='
@@ -15,6 +15,8 @@
       displayList: []
       widgetTitle: 'mnoe_admin_panel.dashboard.users.widget.local_list.loading_users.title'
       search: ''
+
+    scope.isImpersonationEnabled = MnoeAdminConfig.isImpersonationEnabled()
 
     # Display all the users
     setAllUsersList = () ->

--- a/src/app/components/mnoe-users-local-list/mnoe-users-local-list.html
+++ b/src/app/components/mnoe-users-local-list/mnoe-users-local-list.html
@@ -10,7 +10,7 @@
           <th translate>mnoe_admin_panel.dashboard.users.widget.local_list.table.username</th>
           <th style="width: 100px;" translate>mnoe_admin_panel.dashboard.users.widget.local_list.table.creation</th>
           <th style="width: 140px;" translate>mnoe_admin_panel.dashboard.users.widget.local_list.table.status</th>
-          <th style="width: 100px;"></th>
+          <th style="width: 100px;" ng-if="isImpersonationEnabled"></th>
         </tr>
       </thead>
       <tbody>
@@ -34,7 +34,7 @@
             </button>
             <span ng-show="user.status === 'active'" translate>mnoe_admin_panel.dashboard.users.widget.local_list.active</span>
           </td>
-          <td><a href="" ng-click="impersonateUser(user)" translate>mnoe_admin_panel.dashboard.users.widget.local_list.login_as</a></td>
+          <td ng-if="isImpersonationEnabled"><a href="" ng-click="impersonateUser(user)" translate>mnoe_admin_panel.dashboard.users.widget.local_list.login_as</a></td>
         </tr>
       </tbody>
     </table>

--- a/src/app/index.default-config.coffee
+++ b/src/app/index.default-config.coffee
@@ -4,3 +4,4 @@
 #   Uncaught Error: [$injector:unpr] Unknown provider: INTERCOM_IDProvider <- INTERCOM_ID <- AnalyticsSvc
 angular.module('mnoEnterprise.defaultConfiguration', [])
   .constant('REVIEWS_CONFIG', {enabled: false})
+  .constant('ADMIN_PANEL_CONFIG', {})

--- a/src/app/index.route.coffee
+++ b/src/app/index.route.coffee
@@ -1,4 +1,4 @@
-@App.config ($stateProvider, $urlRouterProvider) ->
+@App.config ($stateProvider, $urlRouterProvider, MnoeAdminConfigProvider) ->
   'ngInject'
   $stateProvider
     .state 'dashboard',
@@ -15,15 +15,6 @@
       controllerAs: 'vm'
       ncyBreadcrumb:
         label: 'mnoe_admin_panel.dashboard.home.title'
-    .state 'dashboard.finance',
-      data:
-        pageTitle:'Finance'
-      url: '/finance'
-      templateUrl: 'app/views/finance/finance.html'
-      controller: 'FinanceController'
-      controllerAs: 'vm'
-      ncyBreadcrumb:
-        label: 'mnoe_admin_panel.dashboard.finance.title'
     .state 'dashboard.staff',
       data:
         pageTitle:'Staff'
@@ -91,5 +82,16 @@
         controllerAs: 'vm'
       ncyBreadcrumb:
         label: 'mnoe_admin_panel.dashboard.customers.connect_app.title'
+
+  if MnoeAdminConfigProvider.$get().isFinanceEnabled()
+    $stateProvider.state 'dashboard.finance',
+      data:
+        pageTitle:'Finance'
+      url: '/finance'
+      templateUrl: 'app/views/finance/finance.html'
+      controller: 'FinanceController'
+      controllerAs: 'vm'
+      ncyBreadcrumb:
+        label: 'mnoe_admin_panel.dashboard.finance.title'
 
   $urlRouterProvider.otherwise '/home'

--- a/src/app/index.route.coffee
+++ b/src/app/index.route.coffee
@@ -15,17 +15,6 @@
       controllerAs: 'vm'
       ncyBreadcrumb:
         label: 'mnoe_admin_panel.dashboard.home.title'
-    .state 'dashboard.staff',
-      data:
-        pageTitle:'Staff'
-      url: '/staff' #:staffId
-      templateUrl: 'app/views/staff/staff.html'
-      controller: 'StaffController'
-      controllerAs: 'vm'
-      ncyBreadcrumb:
-        label: 'mnoe_admin_panel.dashboard.staff.title'
-      resolve:
-        skip: (MnoeCurrentUser) -> MnoeCurrentUser.skipIfNotAdmin()
     .state 'dashboard.reviews',
       data:
         pageTitle:'Reviews'
@@ -83,7 +72,10 @@
       ncyBreadcrumb:
         label: 'mnoe_admin_panel.dashboard.customers.connect_app.title'
 
-  if MnoeAdminConfigProvider.$get().isFinanceEnabled()
+  # Routes depending on Feature Flags
+  adminConfig = MnoeAdminConfigProvider.$get()
+
+  if adminConfig.isFinanceEnabled()
     $stateProvider.state 'dashboard.finance',
       data:
         pageTitle:'Finance'
@@ -93,5 +85,18 @@
       controllerAs: 'vm'
       ncyBreadcrumb:
         label: 'mnoe_admin_panel.dashboard.finance.title'
+
+  if adminConfig.isStaffEnabled()
+    $stateProvider.state 'dashboard.staff',
+      data:
+        pageTitle:'Staff'
+      url: '/staff' #:staffId
+      templateUrl: 'app/views/staff/staff.html'
+      controller: 'StaffController'
+      controllerAs: 'vm'
+      ncyBreadcrumb:
+        label: 'mnoe_admin_panel.dashboard.staff.title'
+      resolve:
+        skip: (MnoeCurrentUser) -> MnoeCurrentUser.skipIfNotAdmin()
 
   $urlRouterProvider.otherwise '/home'

--- a/src/app/index.route.coffee
+++ b/src/app/index.route.coffee
@@ -55,14 +55,6 @@
         controllerAs: 'vm'
       ncyBreadcrumb:
         label: 'mnoe_admin_panel.dashboard.organization.title'
-    .state 'dashboard.customers.create-step-1',
-      url: '^/customers/create-customer'
-      views: '@dashboard':
-        templateUrl: 'app/views/customers/create-step-1/create-step-1.html'
-        controller: 'CreateStep1Controller'
-        controllerAs: 'vm'
-      ncyBreadcrumb:
-        label: 'mnoe_admin_panel.dashboard.customers.create_customer.title'
     .state 'dashboard.customers.connect-app',
       url: '^/customers/:orgId/connect-apps'
       views: '@dashboard':
@@ -98,5 +90,15 @@
         label: 'mnoe_admin_panel.dashboard.staff.title'
       resolve:
         skip: (MnoeCurrentUser) -> MnoeCurrentUser.skipIfNotAdmin()
+
+  if adminConfig.isOrganizationManagementEnabled()
+    $stateProvider.state 'dashboard.customers.create-step-1',
+      url: '^/customers/create-customer'
+      views: '@dashboard':
+        templateUrl: 'app/views/customers/create-step-1/create-step-1.html'
+        controller: 'CreateStep1Controller'
+        controllerAs: 'vm'
+      ncyBreadcrumb:
+        label: 'mnoe_admin_panel.dashboard.customers.create_customer.title'
 
   $urlRouterProvider.otherwise '/home'

--- a/src/app/views/customers/create-step-1/create-step-1.controller.coffee
+++ b/src/app/views/customers/create-step-1/create-step-1.controller.coffee
@@ -1,4 +1,4 @@
-@App.controller 'CreateStep1Controller', ($scope, $document, $state, toastr, MnoeOrganizations, MnoeMarketplace, MnoErrorsHandler) ->
+@App.controller 'CreateStep1Controller', ($scope, $document, $state, toastr, MnoeAdminConfig, MnoeOrganizations, MnoeMarketplace, MnoErrorsHandler) ->
   'ngInject'
   vm = this
 
@@ -24,7 +24,7 @@
     MnoErrorsHandler.resetErrors(vm.form)
 
     # List of checked apps
-    vm.organization.app_nids = _.map(_.filter(vm.marketplace.apps, {checked: true}), 'nid')
+    vm.organization.app_nids = _.map(_.filter(vm.marketplace.apps, {checked: true}), 'nid') if MnoeAdminConfig.isAppManagementEnabled()
 
     MnoeOrganizations.create(vm.organization).then(
       (response) ->
@@ -47,6 +47,6 @@
     (response) ->
       # Copy the marketplace as we will work on the cached object
       vm.marketplace = angular.copy(response.data)
-  )
+  ) if MnoeAdminConfig.isAppManagementEnabled()
 
   return

--- a/src/app/views/customers/create-step-1/create-step-1.html
+++ b/src/app/views/customers/create-step-1/create-step-1.html
@@ -20,7 +20,7 @@
           </mno-widget-body>
         </mno-widget>
 
-        <mno-widget class="top-buffer-2" is-loading="!vm.marketplace" icon="fa-rocket" heading="{{'mnoe_admin_panel.dashboard.customers.create_customer.select_your_app' | translate}}">
+        <mno-widget ng-if="main.adminConfig.isAppManagementEnabled()" class="top-buffer-2" is-loading="!vm.marketplace" icon="fa-rocket" heading="{{'mnoe_admin_panel.dashboard.customers.create_customer.select_your_app' | translate}}">
           <mno-widget-header>
             <input type="text" ng-model="vm.appSearch" placeholder="{{'mnoe_admin_panel.dashboard.customers.create_customer.search' | translate}}" class="form-control input-sm search-bar">
           </mno-widget-header>

--- a/src/app/views/customers/customers.html
+++ b/src/app/views/customers/customers.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="row">
-    <div class="col-xs-12">
+    <div class="col-xs-12" ng-if="main.adminConfig.isOrganizationManagementEnabled()">
       <div class="btn-group pull-right top-buffer-1" uib-dropdown keyboard-nav>
         <button id="simple-btn-keyboard-nav" type="button" class="btn btn-primary" uib-dropdown-toggle>
           {{'mnoe_admin_panel.dashboard.customers.main.new_customer' | translate}} &nbsp;<span class="caret"></span>

--- a/src/app/views/dashboard.controller.coffee
+++ b/src/app/views/dashboard.controller.coffee
@@ -1,4 +1,4 @@
-@App.controller 'DashboardController', ($scope, $cookies, $sce, MnoeMarketplace, MnoErrorsHandler, MnoeCurrentUser, STAFF_PAGE_AUTH, REVIEWS_CONFIG) ->
+@App.controller 'DashboardController', ($scope, $cookies, $sce, MnoeMarketplace, MnoErrorsHandler, MnoeCurrentUser, MnoeAdminConfig, STAFF_PAGE_AUTH, REVIEWS_CONFIG) ->
   'ngInject'
   main = this
 
@@ -6,6 +6,8 @@
   main.staffPageAuthorized = STAFF_PAGE_AUTH
 
   main.isReviewingEnabled = REVIEWS_CONFIG && REVIEWS_CONFIG.enabled
+  main.isFinanceEnabled = MnoeAdminConfig.isFinanceEnabled()
+  main.adminConfig = MnoeAdminConfig
 
   main.trustSrc = (src) ->
     $sce.trustAsResourceUrl(src)

--- a/src/app/views/dashboard.layout.html
+++ b/src/app/views/dashboard.layout.html
@@ -40,7 +40,7 @@
     <li class="sidebar-list" ui-sref-active="active">
       <a ui-sref="dashboard.customers">{{'mnoe_admin_panel.dashboard.layout.sidebar.customers' | translate}}<span class="menu-icon fa fa-users"></span></a>
     </li>
-    <li class="sidebar-list" ng-show="main.staffPageAuthorized.indexOf(main.user.admin_role)!=-1" ui-sref-active="active">
+    <li class="sidebar-list" ng-show="main.staffPageAuthorized.indexOf(main.user.admin_role)!=-1" ng-if="main.adminConfig.isStaffEnabled()" ui-sref-active="active">
       <a ui-sref="dashboard.staff">{{'mnoe_admin_panel.dashboard.layout.sidebar.staff' | translate}}<span class="menu-icon fa fa-wrench"></span></a>
     </li>
     <li class="sidebar-list" ng-show="main.staffPageAuthorized.indexOf(main.user.admin_role)!=-1" ng-if="main.isReviewingEnabled" ui-sref-active="active">

--- a/src/app/views/dashboard.layout.html
+++ b/src/app/views/dashboard.layout.html
@@ -34,7 +34,7 @@
     <li class="sidebar-list" ui-sref-active="active">
       <a ui-sref="dashboard.home">{{'mnoe_admin_panel.dashboard.layout.sidebar.home' | translate}}<span class="menu-icon fa fa-tachometer"></span></a>
     </li>
-    <li class="sidebar-list" ui-sref-active="active">
+    <li class="sidebar-list" ng-if="main.isFinanceEnabled" ui-sref-active="active">
       <a ui-sref="dashboard.finance">{{'mnoe_admin_panel.dashboard.layout.sidebar.finance' | translate}}<span class="menu-icon fa fa-money"></span></a>
     </li>
     <li class="sidebar-list" ui-sref-active="active">

--- a/src/app/views/home/home.controller.coffee
+++ b/src/app/views/home/home.controller.coffee
@@ -1,4 +1,4 @@
-@App.controller 'HomeController', (moment, MnoeUsers, MnoeOrganizations, MnoeInvoices) ->
+@App.controller 'HomeController', (moment, MnoeUsers, MnoeOrganizations, MnoeInvoices, MnoeAdminConfig) ->
   'ngInject'
   vm = this
 
@@ -20,11 +20,11 @@
   MnoeInvoices.lastInvoicingAmount().then(
     (response) ->
       vm.invoices.lastInvoicingAmount = response.data
-  )
+  ) if MnoeAdminConfig.isFinanceEnabled()
 
   MnoeInvoices.outstandingAmount().then(
     (response) ->
       vm.invoices.outstandingAmount = response.data
-  )
+  ) if MnoeAdminConfig.isFinanceEnabled()
 
   return

--- a/src/app/views/home/home.html
+++ b/src/app/views/home/home.html
@@ -11,13 +11,13 @@
              loading="!vm.organizations.kpi" mno-ui-sref="dashboard.customers" link-text="{{'mnoe_admin_panel.dashboard.home.kpi.organizations.link_text' | translate:{'quantity': vm.organizations.kpi.with_cc_count} }}"></mno-kpi>
   </div>
 
-  <div class="col-lg-3 col-md-6 col-xs-12">
+  <div class="col-lg-3 col-md-6 col-xs-12" ng-if="main.adminConfig.isFinanceEnabled()">
     <mno-kpi class="kpi-color-3" description="{{'mnoe_admin_panel.dashboard.home.kpi.last_customer_invoicing' | translate}}" icon="fa-file-text-o"
              value="{{vm.invoices.lastInvoicingAmount.amount}}" unit="{{vm.invoices.lastInvoicingAmount.currency}}"
              loading="!vm.invoices.lastInvoicingAmount" mno-ui-sref="dashboard.finance" link-text="{{'mnoe_admin_panel.dashboard.home.kpi.last_customer_invoicing.link_text' | translate}}"></mno-kpi>
   </div>
 
-  <div class="col-lg-3 col-md-6 col-xs-12">
+  <div class="col-lg-3 col-md-6 col-xs-12" ng-if="main.adminConfig.isFinanceEnabled()">
     <mno-kpi class="kpi-color-4" description="{{'mnoe_admin_panel.dashboard.home.kpi.to_be_paid' | translate}}" icon="fa-money"
              value="{{vm.invoices.outstandingAmount.amount}}" unit="{{vm.invoices.outstandingAmount.currency}}"
              loading="!vm.invoices.outstandingAmount" mno-ui-sref="dashboard.finance" link-text="{{'mnoe_admin_panel.dashboard.home.kpi.to_be_paid.link_text' | translate}}"></mno-kpi>

--- a/src/app/views/organization/organization.html
+++ b/src/app/views/organization/organization.html
@@ -49,7 +49,7 @@
       </mno-widget>
     </div>
   </div>
-  <div class="row">
+  <div class="row" ng-if="main.adminConfig.isUserManagementEnabled()">
     <div class="col-xs-12 top-buffer-1">
       <button role="button" ng-click="vm.users.createUserModal()" ng-disabled="!vm.organization" class="btn btn-primary" translate>
         mnoe_admin_panel.dashboard.organization.add_a_user

--- a/src/app/views/organization/organization.html
+++ b/src/app/views/organization/organization.html
@@ -60,7 +60,7 @@
     <div class="col-md-6">
       <mnoe-users-local-list list="vm.organization.members" organization="vm.organization" view="all"></mnoe-users-local-list>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6" ng-if="main.adminConfig.isFinanceEnabled()">
       <mno-widget icon="fa-file-text-o" heading="{{'mnoe_admin_panel.dashboard.organization.invoices.title' | translate}}" is-loading="!vm.organization.invoices" >
         <mno-widget-header></mno-widget-header>
         <mno-widget-body class="medium no-padding">

--- a/src/app/views/organization/organization.html
+++ b/src/app/views/organization/organization.html
@@ -30,14 +30,14 @@
               <div class="bs-row row apps-box">
                 <div class="app-wrapper col-xs-6 col-sm-4 col-md-3" ng-repeat="app in vm.organization.active_apps">
                   <div class="small-app-card ellipsis">
-                    <i class="fa fa-trash app-remove" ng-click="vm.openRemoveAppModal(app, $index)" uib-tooltip="{{'mnoe_admin_panel.dashboard.organization.remove_app' | translate:{'app_name': app.app_name} }}" tooltip-append-to-body="true"></i>
+                    <i ng-if="main.adminConfig.isAppManagementEnabled()" class="fa fa-trash app-remove" ng-click="vm.openRemoveAppModal(app, $index)" uib-tooltip="{{'mnoe_admin_panel.dashboard.organization.remove_app' | translate:{'app_name': app.app_name} }}" tooltip-append-to-body="true"></i>
                     <i ng-show="vm.status[app.nid]" class="fa fa-check-circle app-state state-success" uib-tooltip="{{'mnoe_admin_panel.dashboard.organization.app_connected' | translate:{'app_name': app.app_name} }}" tooltip-append-to-body="true"></i>
                     <i ng-show="!vm.status[app.nid]" class="fa fa-exclamation-circle app-state state-warning" uib-tooltip="{{'mnoe_admin_panel.dashboard.organization.app_not_connected' | translate:{'app_name': app.app_name} }}" tooltip-append-to-body="true"></i>
                     <img ng-src="{{::app.app_logo}}" width="60">
                     <span>{{::app.app_name}}</span>
                   </div>
                 </div>
-                <div class="app-wrapper col-xs-6 col-sm-4 col-md-3">
+                <div class="app-wrapper col-xs-6 col-sm-4 col-md-3" ng-if="main.adminConfig.isAppManagementEnabled()">
                   <div class="small-app-card ellipsis add-app" ng-click="vm.openAddAppModal()">
                     <span>{{'mnoe_admin_panel.dashboard.organization.add_an_app' | translate}}<i class="fa fa-plus"></i></span>
                   </div>

--- a/src/app/views/user/user.html
+++ b/src/app/views/user/user.html
@@ -45,7 +45,7 @@
       </div>
     </div>
     <div class="bs-row">
-      <div class="col-sm-4 col-sm-offset-4">
+      <div class="col-sm-4 col-sm-offset-4" ng-if="main.adminConfig.isImpersonationEnabled()">
         <button class="btn btn-primary center-block" ng-click="vm.impersonateUser()" translate>mnoe_admin_panel.dashboard.user.login_button</button>
       </div>
       <div class="col-sm-12 top-buffer-2">


### PR DESCRIPTION
@fgourichon @alexnoox add the following feature flags:

```yaml
# Admin Panel Config
admin_panel:
  # Disable Impersonation
  impersonation:
    disabled: false
  staff:
    enabled: true
  finance:
    enabled: true
  apps_management:
    enabled: true
  customer_management:
    organization:
      enabled: true
    user:
      enabled: true
```
(See https://github.com/maestrano/mno-enterprise/pull/258)

- impersonation => backported from mnoe
- staff => disable the staff management
- finance => disable the finance page, the financial kpis and the invoices
- apps_management => disabled adding/removing apps (we can still connect them)
- customer_mangement
  - organization => Disable customer creation / invite
  - user => disable adding users


@alexnoox, a couple questions:

* What do you think of wrapping the `ADMIN_CONFIG` constant in a service? This allow to have proper defaults and a nicer code.

* What would be the best way, exposing it through the dashboard controller like:
```coffeescript
main.adminConfig = MnoeAdminConfig
```
```html
<.. ng-if="main.adminConfig.isFinanceEnabled()">
```

Or exposing variables:
```coffeescript
main.isFinanceEnabled = MnoeAdminConfig.isFinanceEnabled()
```
```html
<... ng-if="main.isFinanceEnabled">
```

* Also should we use one-way binding for this kind of `ng-if`?

Looks like the Service is initialised multiple times because of the
`MnoeAdminConfigProvider.$get()` in the `config` block (for the routes).
I've assigned it to a variable to have it only instantiated twice (routes & app)
