### PR TITLE
[MNOE-664] Breakdown order list screen

### DIFF
--- a/src/app/components/mnoe-subscriptions-list/mnoe-subscriptions-list.coffee
+++ b/src/app/components/mnoe-subscriptions-list/mnoe-subscriptions-list.coffee
@@ -5,14 +5,16 @@
   templateUrl: 'app/components/mnoe-subscriptions-list/mnoe-subscriptions-list.html',
   bindings: {
     all: '<'
-    organization: '<'
+    organization: '<',
+    filters: '<'
+    titleKey: '@'
   }
   controller: ($filter, $log, toastr, MnoeUsers, MnoeCurrentUser, MnoConfirm, MnoeProvisioning) ->
     ctrl = this
 
     ctrl.subscriptions =
       list: []
-      sort: "start_date"
+      sort: "created_at.desc"
       nbItems: 10
       offset: 0
       page: 1
@@ -40,6 +42,9 @@
             )
 
         MnoConfirm.showModal(modalOptions)
+
+    ctrl.$onInit = ->
+      ctrl.titleText = "mnoe_admin_panel.dashboard.subscriptions.widget.list.#{ctrl.titleKey || 'title'}"
 
     ctrl.$onChanges = () ->
       # Call the server when ready
@@ -72,7 +77,11 @@
     # Fetch subscriptions
     fetchSubscriptions = (limit, offset, sort = ctrl.subscriptions.sort) ->
       ctrl.subscriptions.loading = true
-      return MnoeProvisioning.getSubscriptions(limit, offset, sort, ctrl.organization?.id).then(
+
+      # Add extra filtering
+      extra_params = ctrl.filters || {}
+
+      return MnoeProvisioning.getSubscriptions(limit, offset, sort, ctrl.organization?.id, extra_params).then(
         (response) ->
           ctrl.subscriptions.totalItems = response.headers('x-total-count')
           ctrl.subscriptions.list = response.data

--- a/src/app/components/mnoe-subscriptions-list/mnoe-subscriptions-list.html
+++ b/src/app/components/mnoe-subscriptions-list/mnoe-subscriptions-list.html
@@ -1,6 +1,6 @@
 <mno-widget icon="fa-shopping-basket" heading="{{$ctrl.subscriptions.widgetTitle}}" is-loading="$ctrl.subscriptions.loading">
   <mno-widget-header>
-    &nbsp;{{ 'mnoe_admin_panel.dashboard.subscriptions.widget.list.title' | translate}}
+    &nbsp;{{ $ctrl.titleText | translate}}
   </mno-widget-header>
   <mno-widget-body class="large no-padding">
     <div>

--- a/src/app/views/orders/orders.html
+++ b/src/app/views/orders/orders.html
@@ -1,5 +1,11 @@
 <div class="row">
   <div class="col-lg-10 col-lg-offset-1 col-md-12">
-    <mnoe-subscriptions-list all="true"></mnoe-subscriptions-list>
+    <mnoe-subscriptions-list all="true" title-key="title_with_action" filters="{ 'where[status.in]': 'requested,approved' }"></mnoe-subscriptions-list>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-lg-10 col-lg-offset-1 col-md-12">
+    <mnoe-subscriptions-list all="true" title-key="title_with_history" filters="{ 'where[status.nin]': 'requested,approved' }"></mnoe-subscriptions-list>
   </div>
 </div>

--- a/src/locales/en-AU.json
+++ b/src/locales/en-AU.json
@@ -361,6 +361,8 @@
   "mnoe_admin_panel.dashboard.provisioning.subscriptions.cancel_error": "An error occurred while canceling this subscription. Please contact your administrator.",
   "mnoe_admin_panel.dashboard.provisioning.subscriptions.empty_list": "You don't have any subscriptions",
   "mnoe_admin_panel.dashboard.subscriptions.widget.list.title": "Orders",
+  "mnoe_admin_panel.dashboard.subscriptions.widget.list.title_with_action": "Orders requiring your attention",
+  "mnoe_admin_panel.dashboard.subscriptions.widget.list.title_with_history": "Past Orders",
   "mnoe_admin_panel.dashboard.subscriptions.widget.list.table.organization": "Organization",
   "mnoe_admin_panel.dashboard.subscriptions.widget.list.table.product": "Product",
   "mnoe_admin_panel.dashboard.subscriptions.widget.list.table.subscription": "Subscription",


### PR DESCRIPTION
Break down the order screen to split orders between "orders to action" and "history". Also default the sorting to most recent orders first.

<img width="1033" alt="screen shot 2017-09-21 at 9 03 17 pm" src="https://user-images.githubusercontent.com/469637/30725128-644274f6-9f10-11e7-99af-950ab77563d6.png">
