### PR TITLE
[MNOE-682] Add Intercom to the Admin Panel

### DIFF
--- a/src/app/components/intercom/intercom.svc.coffee
+++ b/src/app/components/intercom/intercom.svc.coffee
@@ -22,7 +22,6 @@
           $window.Intercom('boot', userData)
       )
 
-
   # Will update in every page change so intercom knows we're still active and load new messages
   @update = () ->
     $window.Intercom('update') if $window.Intercom

--- a/src/app/components/intercom/intercom.svc.coffee
+++ b/src/app/components/intercom/intercom.svc.coffee
@@ -1,0 +1,34 @@
+@App.service 'IntercomSvc', ($window, MnoeCurrentUser, INTERCOM_ID) ->
+  @init = () ->
+    if $window.Intercom
+      MnoeCurrentUser.getUser().then(
+        (response) ->
+          userData = {
+            app_id: INTERCOM_ID,
+            user_id: response.id,
+            email: response.email,
+            admin_role: response.admin_role,
+            name: response.name,
+            surname: response.surname,
+            created_at: response.created_at,
+            widget: {
+              activator: "#IntercomDefaultWidget"
+            }
+          }
+
+          # Add Intercom secure hash
+          userData.user_hash = response.user_hash if response.user_hash
+
+          $window.Intercom('boot', userData)
+      )
+
+
+  # Will update in every page change so intercom knows we're still active and load new messages
+  @update = () ->
+    $window.Intercom('update') if $window.Intercom
+
+  # When user logs out, call to end the Intercom session and clear the cookie.
+  @logOut = ->
+    $window.Intercom('shutdown') if $window.Intercom
+
+  return @

--- a/src/app/components/mnoe-api/admin/current-user.svc.coffee
+++ b/src/app/components/mnoe-api/admin/current-user.svc.coffee
@@ -7,7 +7,7 @@
 # fork of the upstream library
 
 
-@App.service 'MnoeCurrentUser', ($window, $state, $q, $timeout, MnoeApiSvc) ->
+@App.service 'MnoeCurrentUser', ($window, $state, $q, $timeout, IntercomSvc, MnoeApiSvc) ->
   _self = @
 
   # Store the current_user promise
@@ -41,6 +41,9 @@
     return deferred
 
   @logout = ->
+    # Shutdown the Intercom session
+    IntercomSvc.logOut()
+
     _self.getUser().then(
       (response) ->
         # Redirect to dashboard if the user has at least one organization

--- a/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
+++ b/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
@@ -1,6 +1,6 @@
 # This service is a wrapper around the config we fetch from the backend
 # MnoeAdminConfig.financeEnabled?
-@App.factory 'MnoeAdminConfig', ($log, ADMIN_PANEL_CONFIG, PAYMENT_CONFIG, ORGANIZATION_MANAGEMENT, DEVISE_CONFIG) ->
+@App.factory 'MnoeAdminConfig', ($log, ADMIN_PANEL_CONFIG, INTERCOM_ID, PAYMENT_CONFIG, ORGANIZATION_MANAGEMENT, DEVISE_CONFIG) ->
   _self = @
 
   @isAuditLogEnabled = () ->
@@ -8,6 +8,14 @@
       ADMIN_PANEL_CONFIG.audit_log.enabled
     else
       true
+
+  @isIntercomEnabled = () ->
+    if ADMIN_PANEL_CONFIG.intercom?
+      $log.debug(ADMIN_PANEL_CONFIG.intercom.enabled)
+      $log.debug(INTERCOM_ID)
+      ADMIN_PANEL_CONFIG.intercom.enabled && INTERCOM_ID?
+    else
+      false
 
   @isImpersonationEnabled = () ->
     if ADMIN_PANEL_CONFIG.impersonation

--- a/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
+++ b/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
@@ -11,8 +11,6 @@
 
   @isIntercomEnabled = () ->
     if ADMIN_PANEL_CONFIG.intercom?
-      $log.debug(ADMIN_PANEL_CONFIG.intercom.enabled)
-      $log.debug(INTERCOM_ID)
       ADMIN_PANEL_CONFIG.intercom.enabled && INTERCOM_ID?
     else
       false

--- a/src/app/index.controller.coffee
+++ b/src/app/index.controller.coffee
@@ -1,0 +1,19 @@
+@App.controller 'IndexController', ($scope, $sce, INTERCOM_ID, MnoeAdminConfig) ->
+  'ngInject'
+
+  $scope.intercom = $sce.trustAsHtml("""
+      <script>
+        window.intercomSettings = {
+          app_id: "#{INTERCOM_ID}"
+        };
+      </script>
+      <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');
+        ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];
+        i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');
+        s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/#{INTERCOM_ID}';
+        var x=d.getElementsByTagName('script')[0];
+        x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+      </script>
+  """)if MnoeAdminConfig.isIntercomEnabled()
+
+  return

--- a/src/app/index.run.coffee
+++ b/src/app/index.run.coffee
@@ -37,3 +37,12 @@
       toastr[message.type](message.msg, _.capitalize(message.type), timeout: 10000)
       $location.search('flash', null) # remove the flash from url
   )
+
+  # Intercom
+  .run(($rootScope, $timeout, IntercomSvc) ->
+    # Init Intercom once app is loaded
+    $timeout(-> IntercomSvc.init())
+
+    # Track page change
+    $rootScope.$on("$stateChangeStart", -> IntercomSvc.update())
+  )

--- a/src/index.html
+++ b/src/index.html
@@ -41,5 +41,9 @@
     <!-- endbuild -->
 
     <script src="/assets/mno_enterprise/config.js"></script>
+
+    <!-- Intercom -->
+    <div ng-controller="IndexController" ng-bind-html="intercom"></div>
+    <!-- End Intercom -->
   </body>
 </html>


### PR DESCRIPTION
Ability to enabled Intercom in the Admin Panel if it's properly
configured for the dashboard.
We push the admin_role to be able to differentiate admin.

Notes:
* I didn't patch the Intercom loader script as we did for the dashboard as it seems to be working, we'll do more testing in UAT and I'll patch it if needed
* @alexnoox Instead of `IntercomSvc` would it be better to pick a more generic name to be able to abstract the support system we use? (We can alway rename if we have to implement a different system)