### PR TITLE
[MNOE-777] Improve user and organisations table

### DIFF
--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.coffee
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.coffee
@@ -70,31 +70,14 @@
         ).finally(-> scope.organizations.loading = false)
       )
 
-    scope.switchState = () ->
-      scope.state = attrs.view = if attrs.view == 'all' then 'last' else 'all'
-      displayCurrentState()
-
-    # if view="all" is set on the directive, all the users are displayed
-    # if view="last" is set on the directive, the last 10 users are displayed
     displayCurrentState = () ->
-      if attrs.view == 'all'
-        setAllOrganizationsList()
-        fetchOrganizations(scope.organizations.nbItems, 0)
-      else if attrs.view == 'last'
-        setLastOrganizationsList()
-        fetchOrganizations(scope.organizations.nbItems, 0, 'created_at.desc')
-      else
-        $log.error('Value of attribute view can only be "all" or "last"')
+      setAllOrganizationsList()
+      fetchOrganizations(scope.organizations.nbItems, 0)
 
     # Display all the organisations
     setAllOrganizationsList = () ->
       scope.organizations.widgetTitle = 'mnoe_admin_panel.dashboard.organization.widget.list.all_organizations.title'
       scope.organizations.switchLinkTitle = 'mnoe_admin_panel.dashboard.organization.widget.list.all_users.switch_link_title'
-
-    # Display only the last 10 organisations
-    setLastOrganizationsList = () ->
-      scope.organizations.widgetTitle = 'mnoe_admin_panel.dashboard.organization.widget.list.last_organizations.title'
-      scope.organizations.switchLinkTitle = 'mnoe_admin_panel.dashboard.organization.widget.list.last_organizations.switch_link_title'
 
     scope.searchChange = () ->
       # Only search if the string is >= than 3 characters

--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.coffee
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.coffee
@@ -21,13 +21,18 @@
         offset = (page  - 1) * nbItems
         fetchOrganizations(nbItems, offset, scope.organizations.sortAttr)
 
-    $translate(["mnoe_admin_panel.dashboard.organization.account_frozen_state",
+    # table generation - need to get the locale first
+    $translate(
+      ["mnoe_admin_panel.dashboard.organization.account_frozen_state",
       "mnoe_admin_panel.dashboard.organization.widget.list.table.creation",
       'mnoe_admin_panel.dashboard.organization.widget.list.table.name'
       'mnoe_admin_panel.dashboard.organization.widget.list.table.revenue',
       'mnoe_admin_panel.dashboard.organization.widget.list.table.margin'
-      'mnoe_admin_panel.dashboard.organization.widget.list.table.currency']).then((locale) ->
+      'mnoe_admin_panel.dashboard.organization.widget.list.table.currency'])
+      .then((locale) ->
+        # create the fields for the sortable-table
         basicFields = [
+          # organization name
           { header: locale['mnoe_admin_panel.dashboard.organization.widget.list.table.name']
           attr: 'name'
           skip_natural: true
@@ -39,7 +44,9 @@
                 mnoe_admin_panel.dashboard.organization.account_frozen_state</em>
               </a>
             """,
-            scope: {organization: organization} }
+            scope: {organization: organization}}
+
+          # organization creation date
           { header: locale["mnoe_admin_panel.dashboard.organization.widget.list.table.creation"],
           style: {width: '110px'},
           attr:'created_at',
@@ -48,14 +55,21 @@
           render: (organization) ->
             template:
               "<span>{{::organization.created_at | date: 'dd/MM/yyyy'}}</span>"
-            scope: {organization: organization}}]
-        scope.organizations.fields = unless MnoeAdminConfig.isFinanceEnabled() then basicFields else basicFields.concat(
-          [{ header: locale['mnoe_admin_panel.dashboard.organization.widget.list.table.revenue'],
-          attr:'financial_metrics.revenue', donotsort: true, style: width: '110px',}
+            scope: {organization: organization}}
+        ]
+
+        # Add Finance columns if enabled
+        scope.organizations.fields = unless MnoeAdminConfig.isFinanceEnabled() then basicFields else basicFields.concat([
+          # Revenue
+          { header: locale['mnoe_admin_panel.dashboard.organization.widget.list.table.revenue'],
+          attr:'financial_metrics.revenue', doNotSort: true, style: width: '110px',}
+          # Margin
           { header: locale['mnoe_admin_panel.dashboard.organization.widget.list.table.margin'],
-          attr:'financial_metrics.margin', donotsort: true,  style: width: '110px'}
+          attr:'financial_metrics.margin', doNotSort: true,  style: width: '110px'}
+          # Currency
           { header: locale['mnoe_admin_panel.dashboard.organization.widget.list.table.currency'],
-          attr:'financial_metrics.currency', donotsort: true, style: width: '110px'}]))
+          attr:'financial_metrics.currency', doNotSort: true, style: width: '110px'}])
+      )
 
     # Smart table callback
     scope.pipe = (tableState) ->
@@ -63,7 +77,7 @@
       scope.organizations.page = 1
       scope.organizations.sortAttr = tableState.sort.predicate
       if tableState.sort.reverse
-      then scope.organizations.sortAttr += ".desc"
+        scope.organizations.sortAttr += ".desc"
       fetchOrganizations(scope.organizations.nbItems, 0, scope.organizations.sortAttr)
 
     # Fetch organisations

--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.coffee
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.coffee
@@ -7,10 +7,8 @@
     list: '='
   },
   templateUrl: 'app/components/mnoe-organizations-list/mnoe-organizations-list.html',
-  link: (scope, elem, attrs) ->
+  link: (scope, elem) ->
 
-    # Widget state
-    scope.state = attrs.view
     # Variables initialization
     scope.organizations =
       search: ''

--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
@@ -2,7 +2,7 @@
   <mno-widget-header>
     <input type="text" ng-model="organizations.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }' placeholder="{{'mnoe_admin_panel.dashboard.organization.widget.list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
   </mno-widget-header>
-  <mno-widget-body class="large no-padding">
+  <mno-widget-body class="large-auto-height no-padding">
     <mno-sortable-table row-collection="organizations.list" is-loading="organizations.loading" fields="organizations.fields">
     </mno-sortable-table>
   </mno-widget-body>

--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
@@ -1,18 +1,24 @@
 <mno-widget icon="fa-sitemap" heading="{{organizations.widgetTitle | translate}}" is-loading="organizations.loading">
   <mno-widget-header>
-    <input type="text" ng-model="organizations.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }' placeholder="{{'mnoe_admin_panel.dashboard.organization.widget.list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
+    <input type="text" ng-model="organizations.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }'
+    placeholder="{{'mnoe_admin_panel.dashboard.organization.widget.list.search_users.placeholder.search_all' | translate}}"
+    class="form-control input-sm search-bar" />
   </mno-widget-header>
   <mno-widget-body class="large-auto-height no-padding">
-    <mno-sortable-table row-collection="organizations.list" is-loading="organizations.loading" fields="organizations.fields" pipe="pipe(tableState)">
+    <mno-sortable-table
+    row-collection="organizations.list"
+    is-loading="organizations.loading"
+    fields="organizations.fields"
+    pipe="pipe(tableState)">
     </mno-sortable-table>
   </mno-widget-body>
-  <mno-widget-footer ng-show="organizations.list && state == 'all' && !searchMode">
+  <mno-widget-footer ng-show="organizations.list && !searchMode">
     <mno-pagination
-      page="organizations.page"
-      nb-items="organizations.nbItems"
-      total-items="organizations.totalItems"
-      on-change-cb="organizations.pageChangedCb(nbItems, page)"
-      is-loading="organizations.loading">
+    page="organizations.page"
+    nb-items="organizations.nbItems"
+    total-items="organizations.totalItems"
+    on-change-cb="organizations.pageChangedCb(nbItems, page)"
+    is-loading="organizations.loading">
     </mno-pagination>
   </mno-widget-footer>
 </mno-widget>

--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
@@ -3,7 +3,7 @@
     <input type="text" ng-model="organizations.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }' placeholder="{{'mnoe_admin_panel.dashboard.organization.widget.list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
   </mno-widget-header>
   <mno-widget-body class="large-auto-height no-padding">
-    <mno-sortable-table row-collection="organizations.list" is-loading="organizations.loading" fields="organizations.fields">
+    <mno-sortable-table row-collection="organizations.list" is-loading="organizations.loading" fields="organizations.fields" pipe="pipe(tableState)">
     </mno-sortable-table>
   </mno-widget-body>
   <mno-widget-footer ng-show="organizations.list && state == 'all' && !searchMode">

--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
@@ -1,6 +1,5 @@
 <mno-widget icon="fa-sitemap" heading="{{organizations.widgetTitle | translate}}" is-loading="organizations.loading">
   <mno-widget-header>
-    &nbsp;<a href="" ng-click="switchState()" ng-show="organizations.list && organizations.switchLinkTitle" ng-class="{'disabled': organizations.loading}" translate>{{organizations.switchLinkTitle}}</a>
     <input type="text" ng-model="organizations.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }' placeholder="{{'mnoe_admin_panel.dashboard.organization.widget.list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
   </mno-widget-header>
   <mno-widget-body class="large no-padding">

--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
@@ -4,46 +4,8 @@
     <input type="text" ng-model="organizations.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }' placeholder="{{'mnoe_admin_panel.dashboard.organization.widget.list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
   </mno-widget-header>
   <mno-widget-body class="large no-padding">
-    <table class="table table-layout-fixed" st-table="displayedOrganizations" st-safe-src="organizations.list">
-      <thead>
-        <tr>
-          <th st-sort="name" translate>mnoe_admin_panel.dashboard.organization.widget.list.table.name</th>
-          <th st-sort="created_at" st-sort-default="reverse" style="width: 100px;" translate>mnoe_admin_panel.dashboard.organization.widget.list.table.creation</th>
-          <th style="width: 100px;" translate ng-if="isFinanceEnabled" >mnoe_admin_panel.dashboard.organization.widget.list.table.revenue</th>
-          <th style="width: 100px;" translate ng-if="isFinanceEnabled">mnoe_admin_panel.dashboard.organization.widget.list.table.margin</th>
-          <th style="width: 100px;" translate ng-if="isFinanceEnabled">mnoe_admin_panel.dashboard.organization.widget.list.table.currency</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr ng-repeat="organization in displayedOrganizations">
-          <td>
-            <a ui-sref="dashboard.customers.organization({orgId: organization.id})">
-              {{::organization.name}}
-              <em ng-show="organization.account_frozen" class="text-muted" translate>mnoe_admin_panel.dashboard.organization.account_frozen_state</em>
-            </a>
-          </td>
-          <td>{{::organization.created_at | date: 'dd/MM/yyyy'}}</td>
-          <td ng-if="isFinanceEnabled">
-            <span>
-              <div ng-show="organization.financial_metrics.revenue">{{::organization.financial_metrics.revenue}}</div>
-              <div ng-show="!organization.financial_metrics.revenue">nc</div>
-            </span>
-          </td>
-          <td ng-if="isFinanceEnabled">
-            <span>
-              <div ng-show="organization.financial_metrics.margin">{{::organization.financial_metrics.margin}}</div>
-              <div ng-show="!organization.financial_metrics.margin">nc</div>
-            </span>
-          </td>
-          <td ng-if="isFinanceEnabled">
-            <span>
-              <div ng-show="organization.financial_metrics.currency">{{::organization.financial_metrics.currency}}</div>
-              <div ng-show="!organization.financial_metrics.currency">nc</div>
-            </span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <mno-sortable-table row-collection="organizations.list" is-loading="organizations.loading" fields="organizations.fields">
+    </mno-sortable-table>
   </mno-widget-body>
   <mno-widget-footer ng-show="organizations.list && state == 'all' && !searchMode">
     <mno-pagination

--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.html
@@ -4,18 +4,18 @@
     <input type="text" ng-model="organizations.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }' placeholder="{{'mnoe_admin_panel.dashboard.organization.widget.list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
   </mno-widget-header>
   <mno-widget-body class="large no-padding">
-    <table class="table table-layout-fixed">
+    <table class="table table-layout-fixed" st-table="displayedOrganizations" st-safe-src="organizations.list">
       <thead>
         <tr>
-          <th translate>mnoe_admin_panel.dashboard.organization.widget.list.table.name</th>
-          <th style="width: 100px;" translate>mnoe_admin_panel.dashboard.organization.widget.list.table.creation</th>
+          <th st-sort="name" translate>mnoe_admin_panel.dashboard.organization.widget.list.table.name</th>
+          <th st-sort="created_at" st-sort-default="reverse" style="width: 100px;" translate>mnoe_admin_panel.dashboard.organization.widget.list.table.creation</th>
           <th style="width: 100px;" translate ng-if="isFinanceEnabled" >mnoe_admin_panel.dashboard.organization.widget.list.table.revenue</th>
           <th style="width: 100px;" translate ng-if="isFinanceEnabled">mnoe_admin_panel.dashboard.organization.widget.list.table.margin</th>
           <th style="width: 100px;" translate ng-if="isFinanceEnabled">mnoe_admin_panel.dashboard.organization.widget.list.table.currency</th>
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="organization in organizations.list">
+        <tr ng-repeat="organization in displayedOrganizations">
           <td>
             <a ui-sref="dashboard.customers.organization({orgId: organization.id})">
               {{::organization.name}}

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -22,6 +22,16 @@
         offset = (page  - 1) * nbItems
         fetchUsers(nbItems, offset)
 
+    # Getter to sort by full name & handle the null cases
+    scope.getters = {
+      fullname: (user) ->
+        # Empty names are considered as highest
+        user.name + user.surname || "~"
+      last_sign_in_at: (user) ->
+        # Never signed in are considered as lowest
+        user.last_sign_in_at || ""
+    }
+
     # Fetch users
     fetchUsers = (limit, offset, sort = 'surname') ->
       scope.users.loading = true
@@ -31,6 +41,7 @@
           (response) ->
             scope.users.totalItems = response.headers('x-total-count')
             scope.users.list = response.data
+            $log.log scope.users.list
         ).finally(-> scope.users.loading = false)
       )
 

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -69,35 +69,17 @@
           (response) ->
             scope.users.totalItems = response.headers('x-total-count')
             scope.users.list = response.data
-            $log.log scope.users.list
         ).finally(-> scope.users.loading = false)
       )
 
-    scope.switchState = () ->
-      scope.state = attrs.view = if attrs.view == 'all' then 'last' else 'all'
-      displayCurrentState()
-
-    # if view="all" is set on the directive, all the users are displayed
-    # if view="last" is set on the directive, the last 10 users are displayed
     displayCurrentState = () ->
-      if attrs.view == 'all'
-        setAllUsersList()
-        fetchUsers(scope.users.nbItems, 0)
-      else if attrs.view == 'last'
-        setLastUsersList()
-        fetchUsers(10, 0, 'created_at.desc')
-      else
-        $log.error('Value of attribute view can only be "all" or "last"')
+      setAllUsersList()
+      fetchUsers(scope.users.nbItems, 0)
 
     # Display all the users
     setAllUsersList = () ->
       scope.users.widgetTitle = 'mnoe_admin_panel.dashboard.users.widget.list.all_users.title'
       scope.users.switchLinkTitle = 'mnoe_admin_panel.dashboard.users.widget.list.all_users.switch_link_title'
-
-    # Display only the last 10 users
-    setLastUsersList = () ->
-      scope.users.widgetTitle = 'mnoe_admin_panel.dashboard.users.widget.list.last_users.title'
-      scope.users.switchLinkTitle = 'mnoe_admin_panel.dashboard.users.widget.list.last_users.switch_link_title'
 
     scope.searchChange = () ->
       # Only search if the string is >= than 3 characters

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -6,10 +6,7 @@
   scope: {
   }
   templateUrl: 'app/components/mnoe-users-list/mno-users-list.html'
-  link: (scope, elem, attrs) ->
-
-    # Widget state
-    scope.state = attrs.view
+  link: (scope, elem) ->
 
     # Variables initialization
     scope.users =

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -33,7 +33,7 @@
             template: """
             <a ui-sref="dashboard.customers.user({userId: user.id})">
               <div ng-show="user.name && user.surname">{{::user.name}} {{::user.surname}}</div>
-              <div ng-show="!user.name && !user.surname">zzz</div>
+              <div ng-show="!user.name && !user.surname">nc</div>
               <small>{{::user.email}}</small>
             </a>
             """,

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -1,7 +1,7 @@
 #
 # Mnoe Users List
 #
-@App.directive('mnoeUsersList', ($filter, $log, $translate, MnoeUsers, MnoeCurrentUser) ->
+@App.directive('mnoeUsersList', ($filter, $translate, MnoeUsers, MnoeCurrentUser) ->
   restrict: 'E'
   scope: {
   }
@@ -14,13 +14,14 @@
     # Variables initialization
     scope.users =
       search: ''
+      sortAttr: 'created_at'
       nbItems: 10
       page: 1
       pageChangedCb: (nbItems, page) ->
         scope.users.nbItems = nbItems
         scope.users.page = page
         offset = (page  - 1) * nbItems
-        fetchUsers(nbItems, offset)
+        fetchUsers(nbItems, offset, scope.users.sortAttr)
 
     $translate(["mnoe_admin_panel.dashboard.users.widget.list.table.created_at",
       'mnoe_admin_panel.dashboard.users.widget.list.table.username',
@@ -60,6 +61,15 @@
               "<span>{{::user.created_at | date: 'dd/MM/yyyy'}}</span>"
             scope: {user: user}}])
 
+    # Pipe for the sortable-table
+    scope.pipe = (tableState) ->
+      # The order has changed - reset pagination
+      scope.users.page = 1
+      scope.users.sortAttr = tableState.sort.predicate
+      if tableState.sort.reverse
+      then scope.users.sortAttr += ".desc"
+      fetchUsers(scope.users.nbItems, 0, scope.users.sortAttr)
+
     # Fetch users
     fetchUsers = (limit, offset, sort = 'surname') ->
       scope.users.loading = true
@@ -74,7 +84,7 @@
 
     displayCurrentState = () ->
       setAllUsersList()
-      fetchUsers(scope.users.nbItems, 0)
+      fetchUsers(scope.users.nbItems, 0, scope.users.sortAttr)
 
     # Display all the users
     setAllUsersList = () ->

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -22,15 +22,43 @@
         offset = (page  - 1) * nbItems
         fetchUsers(nbItems, offset)
 
-    # Getter to sort by full name & handle the null cases
-    scope.getters = {
-      fullname: (user) ->
-        # Empty names are considered as highest
-        user.name + user.surname || "~"
-      last_sign_in_at: (user) ->
-        # Never signed in are considered as lowest
-        user.last_sign_in_at || ""
-    }
+    $translate(["mnoe_admin_panel.dashboard.users.widget.list.table.created_at",
+      'mnoe_admin_panel.dashboard.users.widget.list.table.username',
+      'mnoe_admin_panel.dashboard.users.widget.list.table.never',
+      'mnoe_admin_panel.dashboard.users.widget.list.table.last_login']).then((locale) ->
+        scope.users.fields = [
+          { header: locale['mnoe_admin_panel.dashboard.users.widget.list.table.username']
+          attr: "surname"
+          render: (user) ->
+            template: """
+            <a ui-sref="dashboard.customers.user({userId: user.id})">
+              <div ng-show="user.name && user.surname">{{::user.name}} {{::user.surname}}</div>
+              <div ng-show="!user.name && !user.surname">zzz</div>
+              <small>{{::user.email}}</small>
+            </a>
+            """,
+            scope: { user: user }
+          skip_natural: true}
+          { header: locale['mnoe_admin_panel.dashboard.users.widget.list.table.last_login']
+          attr: "last_sign_in_at"
+          style: {width: "130px"}
+          render: (user) ->
+            template: """
+            <span data-toggle="tooltip" title="{{::user.last_sign_in_at | date: 'H:m - dd/MM/yyyy'}}">
+              {{(user.last_sign_in_at | amTimeAgo) || ('mnoe_admin_panel.dashboard.users.widget.list.never' | translate)}}
+            </span>
+            """,
+            scope: {user: user}
+          skip_natural: true}
+          { header: locale["mnoe_admin_panel.dashboard.users.widget.list.table.created_at"],
+          style: {width: '130px'},
+          attr:'created_at',
+          sort_default: "reverse"
+          skip_natural: true
+          render: (user) ->
+            template:
+              "<span>{{::user.created_at | date: 'dd/MM/yyyy'}}</span>"
+            scope: {user: user}}])
 
     # Fetch users
     fetchUsers = (limit, offset, sort = 'surname') ->

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -20,11 +20,16 @@
         offset = (page  - 1) * nbItems
         fetchUsers(nbItems, offset, scope.users.sortAttr)
 
-    $translate(["mnoe_admin_panel.dashboard.users.widget.list.table.created_at",
+    # table generation - need to get the locale first
+    $translate([
+      "mnoe_admin_panel.dashboard.users.widget.list.table.created_at",
       'mnoe_admin_panel.dashboard.users.widget.list.table.username',
       'mnoe_admin_panel.dashboard.users.widget.list.table.never',
-      'mnoe_admin_panel.dashboard.users.widget.list.table.last_login']).then((locale) ->
+      'mnoe_admin_panel.dashboard.users.widget.list.table.last_login'])
+      .then((locale) ->
+        # create the fields for the sortable-table
         scope.users.fields = [
+          # User name, surname, and email
           { header: locale['mnoe_admin_panel.dashboard.users.widget.list.table.username']
           attr: "surname"
           render: (user) ->
@@ -37,6 +42,7 @@
             """,
             scope: { user: user }
           skip_natural: true}
+          # User last login date
           { header: locale['mnoe_admin_panel.dashboard.users.widget.list.table.last_login']
           attr: "last_sign_in_at"
           style: {width: "130px"}
@@ -48,6 +54,7 @@
             """,
             scope: {user: user}
           skip_natural: true}
+          # User creation date
           { header: locale["mnoe_admin_panel.dashboard.users.widget.list.table.created_at"],
           style: {width: '130px'},
           attr:'created_at',
@@ -56,7 +63,8 @@
           render: (user) ->
             template:
               "<span>{{::user.created_at | date: 'dd/MM/yyyy'}}</span>"
-            scope: {user: user}}])
+            scope: {user: user}}]
+      )
 
     # Pipe for the sortable-table
     scope.pipe = (tableState) ->
@@ -64,7 +72,7 @@
       scope.users.page = 1
       scope.users.sortAttr = tableState.sort.predicate
       if tableState.sort.reverse
-      then scope.users.sortAttr += ".desc"
+        scope.users.sortAttr += ".desc"
       fetchUsers(scope.users.nbItems, 0, scope.users.sortAttr)
 
     # Fetch users

--- a/src/app/components/mnoe-users-list/mno-users-list.html
+++ b/src/app/components/mnoe-users-list/mno-users-list.html
@@ -4,16 +4,16 @@
     <input type="text" ng-model="users.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }' placeholder="{{'mnoe_admin_panel.dashboard.users.widget.list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
   </mno-widget-header>
   <mno-widget-body class="large no-padding">
-    <table class="table table-layout-fixed">
+    <table class="table table-layout-fixed" st-table="displayedUsers" st-safe-src="users.list">
       <thead>
         <tr>
-          <th translate>mnoe_admin_panel.dashboard.users.widget.list.table.username</th>
-          <th width="110" translate>mnoe_admin_panel.dashboard.users.widget.list.table.last_login</th>
-          <th width="100" translate>mnoe_admin_panel.dashboard.users.widget.list.table.created_at</th>
+          <th st-sort="getters.fullname" translate>mnoe_admin_panel.dashboard.users.widget.list.table.username</th>
+          <th st-sort="getters.last_sign_in_at" width="110" translate>mnoe_admin_panel.dashboard.users.widget.list.table.last_login</th>
+          <th st-sort="created_at" st-sort-default="reverse" width="100" translate>mnoe_admin_panel.dashboard.users.widget.list.table.created_at</th>
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="user in users.list">
+        <tr ng-repeat="user in displayedUsers">
           <td>
             <a ui-sref="dashboard.customers.user({userId: user.id})">
               <div ng-show="user.name && user.surname">{{::user.name}} {{::user.surname}}</div>

--- a/src/app/components/mnoe-users-list/mno-users-list.html
+++ b/src/app/components/mnoe-users-list/mno-users-list.html
@@ -2,7 +2,7 @@
   <mno-widget-header>
     <input type="text" ng-model="users.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }' placeholder="{{'mnoe_admin_panel.dashboard.users.widget.list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
   </mno-widget-header>
-  <mno-widget-body class="large no-padding">
+  <mno-widget-body class="large-auto-height no-padding">
     <mno-sortable-table row-collection="users.list" is-loading="users.loading" fields="users.fields">
     </mno-sortable-table>
   </mno-widget-body>

--- a/src/app/components/mnoe-users-list/mno-users-list.html
+++ b/src/app/components/mnoe-users-list/mno-users-list.html
@@ -1,35 +1,10 @@
 <mno-widget icon="fa-users" heading="{{users.widgetTitle | translate}}" is-loading="users.loading">
   <mno-widget-header>
-    <a href="" ng-click="switchState()" ng-show="users.list && users.switchLinkTitle" ng-class="{'disabled': users.loading}" translate>{{users.switchLinkTitle}}</a>
     <input type="text" ng-model="users.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }' placeholder="{{'mnoe_admin_panel.dashboard.users.widget.list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
   </mno-widget-header>
   <mno-widget-body class="large no-padding">
-    <table class="table table-layout-fixed" st-table="displayedUsers" st-safe-src="users.list">
-      <thead>
-        <tr>
-          <th st-sort="getters.fullname" translate>mnoe_admin_panel.dashboard.users.widget.list.table.username</th>
-          <th st-sort="getters.last_sign_in_at" width="110" translate>mnoe_admin_panel.dashboard.users.widget.list.table.last_login</th>
-          <th st-sort="created_at" st-sort-default="reverse" width="100" translate>mnoe_admin_panel.dashboard.users.widget.list.table.created_at</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr ng-repeat="user in displayedUsers">
-          <td>
-            <a ui-sref="dashboard.customers.user({userId: user.id})">
-              <div ng-show="user.name && user.surname">{{::user.name}} {{::user.surname}}</div>
-              <div ng-show="!user.name && !user.surname">nc</div>
-              <small>{{::user.email}}</small>
-            </a>
-          </td>
-          <td>
-            <span data-toggle="tooltip" title="{{::user.last_sign_in_at | date: 'H:m - dd/MM/yyyy'}}">
-              {{(user.last_sign_in_at | amTimeAgo) || ('mnoe_admin_panel.dashboard.users.widget.list.never' | translate)}}
-            </span>
-          </td>
-          <td>{{::user.created_at | date: 'dd/MM/yyyy'}}</td>
-        </tr>
-      </tbody>
-    </table>
+    <mno-sortable-table row-collection="users.list" is-loading="users.loading" fields="users.fields">
+    </mno-sortable-table>
   </mno-widget-body>
   <mno-widget-footer ng-show="users.list && state == 'all' && !searchMode">
     <mno-pagination

--- a/src/app/components/mnoe-users-list/mno-users-list.html
+++ b/src/app/components/mnoe-users-list/mno-users-list.html
@@ -3,7 +3,7 @@
     <input type="text" ng-model="users.search" ng-change="searchChange()" ng-model-options='{ debounce: 1000 }' placeholder="{{'mnoe_admin_panel.dashboard.users.widget.list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
   </mno-widget-header>
   <mno-widget-body class="large-auto-height no-padding">
-    <mno-sortable-table row-collection="users.list" is-loading="users.loading" fields="users.fields">
+    <mno-sortable-table row-collection="users.list" is-loading="users.loading" fields="users.fields" pipe="pipe(tableState)">
     </mno-sortable-table>
   </mno-widget-body>
   <mno-widget-footer ng-show="users.list && state == 'all' && !searchMode">

--- a/src/app/components/mnoe-users-list/mno-users-list.html
+++ b/src/app/components/mnoe-users-list/mno-users-list.html
@@ -6,7 +6,7 @@
     <mno-sortable-table row-collection="users.list" is-loading="users.loading" fields="users.fields" pipe="pipe(tableState)">
     </mno-sortable-table>
   </mno-widget-body>
-  <mno-widget-footer ng-show="users.list && state == 'all' && !searchMode">
+  <mno-widget-footer ng-show="users.list && !searchMode">
     <mno-pagination
       page="users.page"
       nb-items="users.nbItems"

--- a/src/app/views/customers/customers.html
+++ b/src/app/views/customers/customers.html
@@ -28,10 +28,10 @@
       </div>
     </div>
     <div class="col-xs-12">
-      <mnoe-organizations-list view="all"></mnoe-organizations-list>
+      <mnoe-organizations-list></mnoe-organizations-list>
     </div>
     <div class="col-xs-12">
-      <mnoe-users-list view="all"></mnoe-users-list>
+      <mnoe-users-list></mnoe-users-list>
     </div>
   </div>
 </div>

--- a/src/app/views/home/home.html
+++ b/src/app/views/home/home.html
@@ -38,7 +38,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    <mnoe-organizations-list view="all"></mnoe-organizations-list>
+    <mnoe-organizations-list></mnoe-organizations-list>
   </div>
 </div>
 <div class="row">
@@ -48,6 +48,6 @@
 </div>
 <div class="row">
   <div class="col-md-12">
-    <mnoe-users-list view="all"></mnoe-users-list>
+    <mnoe-users-list></mnoe-users-list>
   </div>
 </div>

--- a/src/app/views/home/home.html
+++ b/src/app/views/home/home.html
@@ -38,7 +38,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    <mnoe-organizations-list view="last"></mnoe-organizations-list>
+    <mnoe-organizations-list view="all"></mnoe-organizations-list>
   </div>
 </div>
 <div class="row">
@@ -48,6 +48,6 @@
 </div>
 <div class="row">
   <div class="col-md-12">
-    <mnoe-users-list view="last"></mnoe-users-list>
+    <mnoe-users-list view="all"></mnoe-users-list>
   </div>
 </div>


### PR DESCRIPTION
The components are also used in the Customer tab: should there also be only the 'show all' mode here ?
I made 'show all' by default and left the 'last 10' option but it will be easy to change.

To handle the case where the names are empty when sorting, I use a default (hidden) value of "~" which works well when comparing against alphanumeric characters, is there another (cleaner) way ? 

Changes: 
 - Organization & User lists uses mno-ui-element's [sortable-table](https://github.com/maestrano/mno-ui-elements/tree/master/src/components/sortable-table), allowing them to be sorted by columns
 - They are sorted by 'created_at' descendant by default
 - They do not have a 'Last 10' option anymore
 - Their height is responsive, with a maximum cap corresponding to ~11 rows (no scrollbar when below the cap \o/)