### PR TITLE
[MNOE-791] Show user lock status

### DIFF
--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -37,7 +37,7 @@
             <a ui-sref="dashboard.customers.user({userId: user.id})">
               <div> <span ng-show="user.name && user.surname">{{::user.name }} {{::user.surname}} </span>
               <span ng-show="!user.name && !user.surname">nc</span>
-              <i title="This user is locked" ng-show="user.access_locked" class="fa fa-lock"> </i>
+              <i title="{{ mnoe_admin_panel.dashboard.users.widget.list.table.lock | translate }}" ng-show="user.access_locked" class="fa fa-lock"> </i>
               </div>
               <small>{{::user.email}}</small>
             </a>

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -35,9 +35,10 @@
           render: (user) ->
             template: """
             <a ui-sref="dashboard.customers.user({userId: user.id})">
-              <div> <span ng-show="user.name && user.surname">{{::user.name }} {{::user.surname}} </span>
-              <span ng-show="!user.name && !user.surname">nc</span>
-              <i title="{{ mnoe_admin_panel.dashboard.users.widget.list.table.lock | translate }}" ng-show="user.access_locked" class="fa fa-lock"> </i>
+              <div>
+                <span ng-show="user.name && user.surname">{{::user.name }} {{::user.surname}}</span>
+                <span ng-show="!user.name && !user.surname">nc</span>
+                <i title="{{ mnoe_admin_panel.dashboard.users.widget.list.table.lock | translate }}" ng-show="user.access_locked" class="fa fa-lock"></i>
               </div>
               <small>{{::user.email}}</small>
             </a>

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -35,8 +35,10 @@
           render: (user) ->
             template: """
             <a ui-sref="dashboard.customers.user({userId: user.id})">
-              <div ng-show="user.name && user.surname">{{::user.name}} {{::user.surname}}</div>
-              <div ng-show="!user.name && !user.surname">nc</div>
+              <div> <span ng-show="user.name && user.surname">{{::user.name }} {{::user.surname}} </span>
+              <span ng-show="!user.name && !user.surname">nc</span>
+              <i title="This user is locked" ng-show="user.locked_at" class="fa fa-lock"> </i>
+              </div>
               <small>{{::user.email}}</small>
             </a>
             """,

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -37,7 +37,7 @@
             <a ui-sref="dashboard.customers.user({userId: user.id})">
               <div> <span ng-show="user.name && user.surname">{{::user.name }} {{::user.surname}} </span>
               <span ng-show="!user.name && !user.surname">nc</span>
-              <i title="This user is locked" ng-show="user.locked_at" class="fa fa-lock"> </i>
+              <i title="This user is locked" ng-show="user.access_locked" class="fa fa-lock"> </i>
               </div>
               <small>{{::user.email}}</small>
             </a>

--- a/src/app/views/user/user.html
+++ b/src/app/views/user/user.html
@@ -41,7 +41,7 @@
             <div class="col-sm-3"><div class="label-cell" translate>mnoe_admin_panel.dashboard.user.table.number_of_sign_in</div></div>
             <div class="col-sm-3">{{vm.user.sign_in_count}}</div>
           </div>
-          <div class="bs-row row" ng-show="vm.user.locked_at">
+          <div class="row" ng-show="vm.user.access_locked">
             <div class="col-sm-3"><div class="label-cell" translate>mnoe_admin_panel.dashboard.user.table.locked_at</div></div>
             <div class="col-sm-3">{{vm.user.locked_at | date: 'dd/MM/yyyy hh:mm'}}</div>
           </div>

--- a/src/app/views/user/user.html
+++ b/src/app/views/user/user.html
@@ -41,6 +41,10 @@
             <div class="col-sm-3"><div class="label-cell" translate>mnoe_admin_panel.dashboard.user.table.number_of_sign_in</div></div>
             <div class="col-sm-3">{{vm.user.sign_in_count}}</div>
           </div>
+          <div class="bs-row row" ng-show="vm.user.locked_at">
+            <div class="col-sm-3"><div class="label-cell" translate>mnoe_admin_panel.dashboard.user.table.locked_at</div></div>
+            <div class="col-sm-3">{{vm.user.locked_at | date: 'dd/MM/yyyy hh:mm'}}</div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/locales/en-AU.json
+++ b/src/locales/en-AU.json
@@ -241,6 +241,7 @@
   "mnoe_admin_panel.dashboard.users.widget.list.table.username": "Username",
   "mnoe_admin_panel.dashboard.users.widget.list.table.last_login": "Last login",
   "mnoe_admin_panel.dashboard.users.widget.list.table.created_at": "Created at",
+  "mnoe_admin_panel.dashboard.users.widget.list.table.lock": "This user is locked",
   "mnoe_admin_panel.dashboard.users.widget.list.never": "never",
   "mnoe_admin_panel.dashboard.users.widget.local_list.all_users.title": "All users ({length})",
   "mnoe_admin_panel.dashboard.users.widget.local_list.all_users.switch_link_title": "(last 10)",

--- a/src/locales/en-AU.json
+++ b/src/locales/en-AU.json
@@ -230,6 +230,7 @@
   "mnoe_admin_panel.dashboard.user.table.last_sign_in": "Last sign in",
   "mnoe_admin_panel.dashboard.user.table.number_of_sign_in": "Number of sign in",
   "mnoe_admin_panel.dashboard.user.table.never_signed_in": "(Never signed in yet)",
+  "mnoe_admin_panel.dashboard.user.table.locked_at": "Locked at",
   "mnoe_admin_panel.dashboard.user.login_button": "Log In as User",
   "mnoe_admin_panel.dashboard.users.widget.list.all_users.title": "All users",
   "mnoe_admin_panel.dashboard.users.widget.list.all_users.switch_link_title": "(last 10)",


### PR DESCRIPTION
Needs `user.locked_at` from https://github.com/maestrano/mno-enterprise/pull/580

The lock icon on the user list widget is based on the previous work at #141 [MNOE-777]