### PR TITLE
Update css for ng-animate bug

### DIFF
--- a/src/app/index.less
+++ b/src/app/index.less
@@ -135,6 +135,10 @@ table {
   z-index: 999;
 }
 
+.ng-hide.ng-hide-animate {
+  display: none !important;
+}
+
 /**
  *  Do not remove the comments below. It's the markers used by gulp-inject to inject
  *  all your less files automatically


### PR DESCRIPTION
@alexnoox This LESS update should take care of an ng-show/ng-hide bug on the admin panel. I will leave comments in the related issue in JIRA. The bug is apparently common and comes from ng-animate, the styling changes prevent the overlap in transitions from ng-show to ng-hide that appear in IE11.  