### PR TITLE
[Support] App logo sizes differ in IE11

### DIFF
--- a/src/app/views/customers/create-step-1/create-step-1.less
+++ b/src/app/views/customers/create-step-1/create-step-1.less
@@ -31,6 +31,7 @@
       }
 
       .app-title {
+        max-width: inherit;
         text-align: center;
         margin-top: 5px;
         .ellipsis;


### PR DESCRIPTION
App titles are not inheriting max-width from icon class
