### PR TITLE
[MNOE-811] Override tabs template to use angular translate filter

### DIFF
--- a/src/app/index.run.coffee
+++ b/src/app/index.run.coffee
@@ -26,24 +26,6 @@
         </div>
         '''
     )
-
-    # Override the default tabs template (JSON schema form) to use angular translate filter
-    $templateCache.put('decorators/bootstrap/tabs.html', '''
-        <div ng-init="selected = { tab: 0 }" class="schema-form-tabs {{form.htmlClass}}">
-        <ul class="nav nav-tabs">
-          <li ng-repeat="tab in form.tabs"
-              ng-disabled="form.readonly"
-              ng-click="$event.preventDefault() || (selected.tab = $index)"
-              ng-class="{active: selected.tab === $index}">
-              <a href="#">{{ tab.title | translate }}</a>
-          </li>
-        </ul>
-
-        <div class="tab-content {{form.fieldHtmlClass}}">
-        </div>
-      </div>
-      '''
-    )
   )
 
   # Display flash messages from the backend in toastr

--- a/src/app/index.run.coffee
+++ b/src/app/index.run.coffee
@@ -26,6 +26,24 @@
         </div>
         '''
     )
+
+    # Override the default tabs template (JSON schema form) to use angular translate filter
+    $templateCache.put('decorators/bootstrap/tabs.html', '''
+        <div ng-init="selected = { tab: 0 }" class="schema-form-tabs {{form.htmlClass}}">
+        <ul class="nav nav-tabs">
+          <li ng-repeat="tab in form.tabs"
+              ng-disabled="form.readonly"
+              ng-click="$event.preventDefault() || (selected.tab = $index)"
+              ng-class="{active: selected.tab === $index}">
+              <a href="#">{{ tab.title | translate }}</a>
+          </li>
+        </ul>
+
+        <div class="tab-content {{form.fieldHtmlClass}}">
+        </div>
+      </div>
+      '''
+    )
   )
 
   # Display flash messages from the backend in toastr

--- a/src/app/views/settings/general/general.controller.coffee
+++ b/src/app/views/settings/general/general.controller.coffee
@@ -11,15 +11,15 @@
       type: "tabs"
       tabs: [
         {
-          title: $translate.instant('mnoe_admin_panel.dashboard.settings.general.tabs.system')
+          title: 'mnoe_admin_panel.dashboard.settings.general.tabs.system'
           items: ["system"]
         }
         {
-          title: $translate.instant('mnoe_admin_panel.dashboard.settings.general.tabs.dashboard')
+          title: 'mnoe_admin_panel.dashboard.settings.general.tabs.dashboard'
           items: ["dashboard"]
         }
         {
-          title: $translate.instant('mnoe_admin_panel.dashboard.settings.general.tabs.admin_panel')
+          title: 'mnoe_admin_panel.dashboard.settings.general.tabs.admin_panel'
           items: ["admin_panel"]
         }
       ]

--- a/src/app/views/settings/general/general.controller.coffee
+++ b/src/app/views/settings/general/general.controller.coffee
@@ -33,7 +33,6 @@
       ]
   )
 
-
   # Remove apps which are no longer enabled
   validateAppList = (appNidList) ->
     if vm.settingsModel?.dashboard?.public_pages?

--- a/src/app/views/settings/general/general.controller.coffee
+++ b/src/app/views/settings/general/general.controller.coffee
@@ -6,25 +6,33 @@
   vm.originalSettings = {}
   vm.settingsSchema = {}
 
-  vm.settingsForm = [
-    {
-      type: "tabs"
-      tabs: [
+  $translate([
+    'mnoe_admin_panel.dashboard.settings.general.tabs.system',
+    'mnoe_admin_panel.dashboard.settings.general.tabs.dashboard',
+    'mnoe_admin_panel.dashboard.settings.general.tabs.admin_panel'
+  ]).then(
+    (translations) ->
+      vm.settingsForm = [
         {
-          title: 'mnoe_admin_panel.dashboard.settings.general.tabs.system'
-          items: ["system"]
-        }
-        {
-          title: 'mnoe_admin_panel.dashboard.settings.general.tabs.dashboard'
-          items: ["dashboard"]
-        }
-        {
-          title: 'mnoe_admin_panel.dashboard.settings.general.tabs.admin_panel'
-          items: ["admin_panel"]
+          type: "tabs"
+          tabs: [
+            {
+              title: translations['mnoe_admin_panel.dashboard.settings.general.tabs.system']
+              items: ["system"]
+            }
+            {
+              title: translations['mnoe_admin_panel.dashboard.settings.general.tabs.dashboard']
+              items: ["dashboard"]
+            }
+            {
+              title: translations['mnoe_admin_panel.dashboard.settings.general.tabs.admin_panel']
+              items: ["admin_panel"]
+            }
+          ]
         }
       ]
-    }
-  ]
+  )
+
 
   # Remove apps which are no longer enabled
   validateAppList = (appNidList) ->


### PR DESCRIPTION
This PR should fix the locale issue on the tabs in the settings page. Previously it was being set with `$translate.instant(...)` This caused an issue if you were already on the settings page. When you hit refresh the schema form is attached to the scope before translations were loaded so the locale keys were shown instead of the translations. 