### PR TITLE
[MNOE-793] Fix title on page load

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,6 @@
     "restangular": "~1.6.1",
     "angular-scroll": "^1.0.0",
     "angular-smart-table": "^2.1.8",
-    "ng-page-title": "^1.1.1",
     "angular-translate": "^2.14.0",
     "angular-translate-handler-log": "^2.14.0",
     "angular-translate-loader-url": "^2.14.0",

--- a/src/app/index.module.coffee
+++ b/src/app/index.module.coffee
@@ -17,7 +17,6 @@
   'smart-table',
   'angularMoment',
   'duScroll',
-  'ngPageTitle',
   'mnoUiElements',
   'pascalprecht.translate',
   'ngSanitize',

--- a/src/app/index.run.coffee
+++ b/src/app/index.run.coffee
@@ -5,6 +5,13 @@
     $rootScope.app_name = APP_NAME
   )
 
+  # Change title on state change - to use ng-bind and make it update with translations
+  .run(($rootScope, $log) ->
+    $rootScope.$on('$stateChangeStart', (event, toState, toParams, fromState, fromParams) ->
+      $rootScope.pageTitle = toState.data.pageTitle
+    )
+  )
+
   # Force the page to scroll to top when a view change
   .run(($rootScope) ->
     $rootScope.$on('$viewContentLoaded', ->

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html ng-app="frontendAdmin" ng-strict-di="true">
   <head>
     <meta charset="utf-8">
-    <title ng-bind="(app_name) + ' - ' + ('mnoe_admin_panel.dashboard.layout.title' | translate) + ' - ' + pageTitle"></title>
+    <title ng-bind="app_name + ' - ' + ('mnoe_admin_panel.dashboard.layout.title' | translate) + ' - ' + pageTitle"></title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html ng-app="frontendAdmin" ng-strict-di="true">
   <head>
     <meta charset="utf-8">
-    <title state-title="{{ 'mnoe_admin_panel.dashboard.layout.title' | translate }}" pattern="{{::app_name}} - {{ 'mnoe_admin_panel.dashboard.layout.title' | translate }} - %s"></title>
+    <title ng-bind="(app_name) + ' - ' + ('mnoe_admin_panel.dashboard.layout.title' | translate) + ' - ' + pageTitle"></title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->


### PR DESCRIPTION
* Uses ng-bind instead of the ng-state-title module
* The title first displays
  mnoe_admin_panel.dashboard.layout.title
   and then gets translated, there might be a solution for this (ng-cloak didn't work).(@alexnoox an idea?)
  This is _only_ on page load (refresh /  type the URL) and not when using the menu