### PR TITLE
[MNOE-823] "Account Manager" feature flag

### DIFF
--- a/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
+++ b/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
@@ -63,6 +63,14 @@
     else
       false
 
+  # If the feature is enabled a "staff" user can be assigned to customers and can only see those ones
+  # If the feature is disabled, the screen to assign customers is not showing and a staff can see all customers (only difference with "admin" in this case is some screens are limited)
+  @isAccountManagerEnabled = () ->
+    if ADMIN_PANEL_CONFIG.account_manager?
+      ADMIN_PANEL_CONFIG.account_manager.enabled
+    else
+      false
+
   # Do not display CC info if Billing or Payment is disabled in the frontend
   @isPaymentEnabled = () ->
     payment_disabled = (PAYMENT_CONFIG? && PAYMENT_CONFIG.disabled)

--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.coffee
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.coffee
@@ -1,7 +1,7 @@
 #
 # Mnoe organizations List
 #
-@App.directive('mnoeOrganizationsList', ($filter, $log, MnoeOrganizations, MnoeCurrentUser) ->
+@App.directive('mnoeOrganizationsList', ($filter, $log, MnoeOrganizations, MnoeCurrentUser, MnoeAdminConfig) ->
   restrict: 'E'
   scope: {
     list: '='
@@ -27,7 +27,10 @@
     fetchOrganizations = (limit, offset, sort = 'name') ->
       scope.organizations.loading = true
       MnoeCurrentUser.getUser().then( ->
-        params = {sub_tenant_id: MnoeCurrentUser.user.mnoe_sub_tenant_id, account_manager_id: MnoeCurrentUser.user.id}
+        params = if MnoeAdminConfig.isAccountManagerEnabled()
+          {sub_tenant_id: MnoeCurrentUser.user.mnoe_sub_tenant_id, account_manager_id: MnoeCurrentUser.user.id}
+        else
+          {}
         return MnoeOrganizations.list(limit, offset, sort, params).then(
           (response) ->
             scope.organizations.totalItems = response.headers('x-total-count')

--- a/src/app/components/mnoe-users-list/mno-users-list.coffee
+++ b/src/app/components/mnoe-users-list/mno-users-list.coffee
@@ -1,7 +1,7 @@
 #
 # Mnoe Users List
 #
-@App.directive('mnoeUsersList', ($filter, $log, $translate, MnoeUsers, MnoeCurrentUser) ->
+@App.directive('mnoeUsersList', ($filter, $log, $translate, MnoeUsers, MnoeCurrentUser, MnoeAdminConfig) ->
   restrict: 'E'
   scope: {
   }
@@ -26,7 +26,10 @@
     fetchUsers = (limit, offset, sort = 'surname') ->
       scope.users.loading = true
       MnoeCurrentUser.getUser().then( ->
-        params = {sub_tenant_id: MnoeCurrentUser.user.mnoe_sub_tenant_id, account_manager_id: MnoeCurrentUser.user.id}
+        params = if MnoeAdminConfig.isAccountManagerEnabled()
+          {sub_tenant_id: MnoeCurrentUser.user.mnoe_sub_tenant_id, account_manager_id: MnoeCurrentUser.user.id}
+        else
+          {}
         return MnoeUsers.list(limit, offset, sort, params).then(
           (response) ->
             scope.users.totalItems = response.headers('x-total-count')

--- a/src/app/views/staff/staff.controller.coffee
+++ b/src/app/views/staff/staff.controller.coffee
@@ -9,6 +9,7 @@
   )
 
   vm.isSubTenantEnabled = MnoeAdminConfig.isSubTenantEnabled()
+  vm.isAccountManagerEnabled = MnoeAdminConfig.isAccountManagerEnabled()
 
   # Get the user
   MnoeUsers.get($stateParams.staffId).then(

--- a/src/app/views/staff/staff.html
+++ b/src/app/views/staff/staff.html
@@ -62,7 +62,7 @@
       </mno-widget-body>
     </mno-widget>
 
-    <div class="bs-row" ng-if="vm.staff && vm.staff.admin_role_was=='staff'">
+    <div class="bs-row" ng-if="vm.staff && vm.staff.admin_role_was =='staff' && vm.isAccountManagerEnabled">
       <div class="col-sm-12">
         <h2><i class="fa fa-users"></i> Clients</h2>
         <button class="btn btn-primary center-block" ng-show="vm.staff"  ng-click="vm.updateClientsModal()" translate>mnoe_admin_panel.dashboard.staff.add_remove_clients</button>


### PR DESCRIPTION
This add a new "Account Manager" feature flag
- If the feature is enabled, a "staff" user can be assigned to customers and can only see those ones (which is the current behaviour)
- If the feature is disabled, the screen to assign customers is not showing and a staff can see all customers (only difference with "admin" in this case is some screens are limited)