### PR TITLE
Invitation management

### DIFF
--- a/src/app/components/mnoe-api/admin/users.svc.coffee
+++ b/src/app/components/mnoe-api/admin/users.svc.coffee
@@ -72,8 +72,8 @@
   @updateUserRole = (organization, user) ->
     MnoeAdminApiSvc.one('/organizations', organization.id).customPUT({member: user}, '/update_member')
 
-  @removeUserFromOrganization = (organization, userEmail) ->
-    data = { member: { email: userEmail } }
+  @removeUserFromOrganization = (organization, user) ->
+    data = { member: user }
     MnoeAdminApiSvc.one('organizations', organization.id).doPUT(data, '/remove_member')
 
   _getStaffs = (limit, offset, sort, params = {}) ->

--- a/src/app/components/mnoe-users-local-list/mnoe-users-local-list.coffee
+++ b/src/app/components/mnoe-users-local-list/mnoe-users-local-list.coffee
@@ -79,9 +79,6 @@
           MnoErrorsHandler.processServerError(error)
       ).finally(-> user.isSendingInvite = false)
 
-    scope.isUserActive = (userStatus) ->
-      userStatus == 'active'
-
     scope.updateUserMail = (user) ->
       user.isUpdatingEmail = true
       MnoeUsers.updateStaff(user).then(

--- a/src/app/components/mnoe-users-local-list/mnoe-users-local-list.coffee
+++ b/src/app/components/mnoe-users-local-list/mnoe-users-local-list.coffee
@@ -115,7 +115,7 @@
         type: 'danger'
 
       MnoConfirm.showModal(modalOptions).then( ->
-        MnoeUsers.removeUserFromOrganization(scope.organization, user.email).then(
+        MnoeUsers.removeUserFromOrganization(scope.organization, user).then(
           () ->
             _.remove(scope.users.displayList, user)
             toastr.success('mnoe_admin_panel.dashboard.users.widget.local_list.remove_member.success', {extraData: {email: user.email}})

--- a/src/app/components/mnoe-users-local-list/mnoe-users-local-list.html
+++ b/src/app/components/mnoe-users-local-list/mnoe-users-local-list.html
@@ -21,8 +21,8 @@
               <div ng-show="user.name && user.surname">{{::user.name}} {{::user.surname}}</div>
               <div ng-show="!user.name && !user.surname">nc</div>
             </a>
-            <small editable-text="user.email" onaftersave="updateUserMail(user)">{{user.email}}</small>
-            <span ng-show="!user.isUpdatingEmail"><i class="fa fa-pencil-square-o fa-1"></i></span>
+            <small editable-text="user.email" onaftersave="updateUserMail(user)" e-form="emailForm">{{user.email}}</small>
+            <span ng-hide="user.isUpdatingEmail || emailForm.$visible" ng-click="emailForm.$show()" ><i class="fa fa-pencil-square-o fa-1"></i></span>
             <span ng-show="user.isUpdatingEmail"><i class="fa fa-spinner fa-pulse fa-fw"></i></span>
           </td>
           <td>{{user.created_at | date: 'dd/MM/yyyy'}}</td>

--- a/src/app/components/mnoe-users-local-list/mnoe-users-local-list.html
+++ b/src/app/components/mnoe-users-local-list/mnoe-users-local-list.html
@@ -35,10 +35,9 @@
               <span ng-show="user.isSendingInvite"><i class="fa fa-spinner fa-pulse fa-fw"></i></span>
               {{'mnoe_admin_panel.dashboard.users.widget.local_list.resend_invite' | translate}}
             </button>
-            <button ng-show="!isUserActive(user.status)" class="btn btn-xs btn-warning" ng-disabled="user.isSendingInvite" ng-click="removeUserFromOrganization(user)">
-              {{'mnoe_admin_panel.dashboard.users.widget.local_list.cancel_invite' | translate}}
-            </button>
-            <span ng-show="isUserActive(user.status)" translate>mnoe_admin_panel.dashboard.users.widget.local_list.active</span>
+            <span ng-show="user.status === 'active'" translate>mnoe_admin_panel.dashboard.users.widget.local_list.active</span>
+            <span ng-show="user.status === 'pending'" ng-click="removeUserFromOrganization(user)" uib-tooltip="{{'mnoe_admin_panel.dashboard.users.widget.local_list.cancel_adding_user' | translate}}"><i class="fa fa-close fa-1"></i></span>
+            <span ng-show="user.status === 'invited'" ng-click="removeUserFromOrganization(user)" uib-tooltip="{{'mnoe_admin_panel.dashboard.users.widget.local_list.cancel_invite' | translate}}"><i class="fa fa-close fa-1"></i></span>
           </td>
           <td>
             <select ng-model="user.role" ng-options="role as keyFromRole(role) | translate for role in availableRoles" ng-change="updateUserRole(user, '{{user.role}}')"></select>

--- a/src/app/components/mnoe-users-local-list/mnoe-users-local-list.html
+++ b/src/app/components/mnoe-users-local-list/mnoe-users-local-list.html
@@ -22,7 +22,7 @@
               <div ng-show="!user.name && !user.surname">nc</div>
             </a>
             <small editable-text="user.email" onaftersave="updateUserMail(user)" e-form="emailForm">{{user.email}}</small>
-            <span ng-hide="user.isUpdatingEmail || emailForm.$visible" ng-click="emailForm.$show()" ><i class="fa fa-pencil-square-o fa-1"></i></span>
+            <span ng-hide="user.isUpdatingEmail || emailForm.$visible" ng-click="emailForm.$show()"><i class="fa fa-pencil-square-o fa-1"></i></span>
             <span ng-show="user.isUpdatingEmail"><i class="fa fa-spinner fa-pulse fa-fw"></i></span>
           </td>
           <td>{{user.created_at | date: 'dd/MM/yyyy'}}</td>

--- a/src/locales/en-AU.json
+++ b/src/locales/en-AU.json
@@ -259,6 +259,7 @@
   "mnoe_admin_panel.dashboard.users.widget.local_list.invite": "Invite",
   "mnoe_admin_panel.dashboard.users.widget.local_list.resend_invite": "Resend Invite",
   "mnoe_admin_panel.dashboard.users.widget.local_list.cancel_invite": "Cancel Invite",
+  "mnoe_admin_panel.dashboard.users.widget.local_list.cancel_adding_user": "Cancel Adding User",
   "mnoe_admin_panel.dashboard.users.widget.local_list.active": "Active",
   "mnoe_admin_panel.dashboard.users.widget.local_list.login_as": "Log In as...",
   "mnoe_admin_panel.dashboard.users.widget.local_list.disabled_tooltip": "This user is a staff member",


### PR DESCRIPTION
<img width="656" alt="screen shot 2017-12-12 at 16 55 44" src="https://user-images.githubusercontent.com/11267460/33897428-551652b2-df5d-11e7-8786-a0e2dbce3186.png">

- For the text-editable email, ability to edit the text by clicking on the fa-icon next to it
- For canceling an invitation or adding a user, simple cross rather than a button before, with a tooltip
- When canceling, by sending the whole object, we can retrieve the user from their id first
