### PR TITLE
Replace gulp-main-bower-files with main-bower-files

### DIFF
--- a/gulp_tasks/misc.js
+++ b/gulp_tasks/misc.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 const gulp = require('gulp');
 const del = require('del');
-const mainBowerFiles = require('gulp-main-bower-files');
+const mainBowerFiles = require('main-bower-files');
 const filter = require('gulp-filter');
 const flatten = require('gulp-flatten');
 
@@ -26,8 +26,7 @@ function fonts() {
 }
 
 function images() {
-  return gulp.src('./bower.json')
-    .pipe(mainBowerFiles())
+  return gulp.src(mainBowerFiles())
     .pipe(filter('**/*.{png,jpg,jpeg,gif}'))
     .pipe(flatten())
     .pipe(gulp.dest(conf.path.dist('/images/')));

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "gulp-inject": "^4.2.0",
     "gulp-insert": "^0.5.0",
     "gulp-less": "^3.0.5",
-    "gulp-main-bower-files": "^1.6.2",
     "gulp-ng-annotate": "^2.0.0",
     "gulp-postcss": "^6.0.1",
     "gulp-replace": "^0.5.4",
@@ -59,7 +58,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-phantomjs-shim": "^1.1.2",
     "lazypipe": "^1.0.1",
-    "main-bower-files": "^2.9.0",
+    "main-bower-files": "^2.13.1",
     "phantomjs-prebuilt": "^2.1.6",
     "uglify-save-license": "^0.4.1",
     "wiredep": "^4.0.0"


### PR DESCRIPTION
It's causing trouble with the deprecation of gulp-utils introduced in
gulp 4.0-alpha3