### PR TITLE
[MNOE-821] App Management when Tenant App Management is disabled

### DIFF
--- a/src/app/views/settings/apps/apps.controller.coffee
+++ b/src/app/views/settings/apps/apps.controller.coffee
@@ -1,8 +1,10 @@
-@App.controller 'SettingsAppsController', ($uibModal, MnoeMarketplace, MnoeApps, MnoConfirm) ->
+@App.controller 'SettingsAppsController', ($uibModal, MnoeMarketplace, MnoeApps, MnoeTenant, MnoConfirm) ->
   'ngInject'
   vm = this
 
   vm.enabledApps = []
+
+  vm.tenantManagement = false
 
   vm.openRemoveAppModal = (app, $index)->
     MnoConfirm.showModal(
@@ -53,6 +55,9 @@
         # Copy the marketplace as we will work on the cached object
         vm.enabledApps = angular.copy(response.data.apps)
     )
+    MnoeTenant.get().then(
+      (response) ->
+        vm.tenantManagement = response.data.app_management == "tenant")
 
   init()
 

--- a/src/app/views/settings/apps/apps.html
+++ b/src/app/views/settings/apps/apps.html
@@ -9,12 +9,12 @@
               <div class="row apps-box">
                 <div class="app-wrapper col-xs-3 col-sm-2 col-md-2" ng-repeat="app in vm.enabledApps">
                   <div class="small-app-card ellipsis">
-                    <i class="fa fa-trash app-remove" ng-click="vm.openRemoveAppModal(app, $index)" uib-tooltip="{{'mnoe_admin_panel.dashboard.organization.remove_app' | translate:{'app_name': app.name} }}" tooltip-append-to-body="true"></i>
+                    <i class="fa fa-trash app-remove" ng-if="vm.tenantManagement" ng-click="vm.openRemoveAppModal(app, $index)" uib-tooltip="{{'mnoe_admin_panel.dashboard.organization.remove_app' | translate:{'app_name': app.name} }}" tooltip-append-to-body="true"></i>
                     <img ng-src="{{::app.logo}}" width="60">
                     <span>{{::app.name}}</span>
                   </div>
                 </div>
-                <div class="app-wrapper col-xs-3 col-sm-2 col-md-2">
+                <div ng-if="vm.tenantManagement" class="app-wrapper col-xs-3 col-sm-2 col-md-2">
                   <div class="small-app-card ellipsis add-app" ng-click="vm.openAddAppModal()">
                     <span>{{'mnoe_admin_panel.dashboard.organization.add_an_app' | translate}}<i class="fa fa-plus"></i></span>
                   </div>


### PR DESCRIPTION
The Settings/Apps screen is Read-Only when the Tenant's
`metadata.app_management` is not set to "tenant"

The metadata is exposed by MNOE via [MNOE#624](https://github.com/maestrano/mno-enterprise/pull/624)