### PR TITLE
[MNOE-806] Fetch details of product only when selected for order

### DIFF
--- a/src/app/components/mno-product-selector/mno-product-selector.controller.coffee
+++ b/src/app/components/mno-product-selector/mno-product-selector.controller.coffee
@@ -10,7 +10,7 @@
     dismiss: '&'
   },
   templateUrl: 'app/components/mno-product-selector/mno-product-selector.html',
-  controller: ($window, orderByFilter) ->
+  controller: ($window, orderByFilter, MnoeProducts) ->
     'ngInject'
 
     $ctrl = this
@@ -32,9 +32,13 @@
         $ctrl.selectedProducts.push(product)
       product.checked = !product.checked
 
-    # Close the modal and return the selected products
+    # Close the modal and return the selected product
     $ctrl.closeModal = ->
-      $ctrl.close({$value: if $ctrl.multiple then $ctrl.selectedProducts else $ctrl.selectedProducts[0]})
+      $ctrl.isLoadingProduct = true
+      MnoeProducts.get($ctrl.selectedProducts[0].id).then(
+        (response) ->
+          $ctrl.close({$value: response.data})
+      ).finally(-> $ctrl.isLoadingProduct = false)
 
     $ctrl.dismissModal = ->
       $ctrl.dismiss()

--- a/src/app/components/mno-product-selector/mno-product-selector.html
+++ b/src/app/components/mno-product-selector/mno-product-selector.html
@@ -30,7 +30,8 @@
         <button ng-click="$ctrl.dismissModal()" class="btn btn-default" translate>
           mnoe_admin_panel.components.mno-product-selector.cancel
         </button>
-        <button ng-click="$ctrl.closeModal()" ng-disabled="$ctrl.selectedProducts.length === 0" class="btn btn-primary arrow">
+        <button ng-click="$ctrl.closeModal()" ng-disabled="$ctrl.selectedProducts.length === 0 || $ctrl.isLoadingProduct" class="btn btn-primary arrow">
+          <span ng-show="$ctrl.isLoadingProduct"><i class="fa fa-spinner fa-pulse fa-fw"></i></span>
           {{$ctrl.actionButtonText | translate}}
         </button>
       </div>

--- a/src/app/views/organization/organization.controller.coffee
+++ b/src/app/views/organization/organization.controller.coffee
@@ -79,12 +79,18 @@
 
   vm.openSelectProductModal = () ->
     vm.isLoadingProducts = true
+    params = {
+      skip_dependencies: true,
+      fields: {
+        products: ['name, logo']
+      }
+    }
     modalInstance = $uibModal.open(
       component: 'mnoProductSelectorModal'
       backdrop: 'static'
       size: 'lg'
       resolve:
-        products: -> MnoeProducts.list().finally(-> vm.isLoadingProducts = false)
+        products: -> MnoeProducts.products(_, _, _, params).finally(-> vm.isLoadingProducts = false)
         multiple: -> false
     )
     modalInstance.result.then(


### PR DESCRIPTION
When hitting create an order from the organization, we would fetch all the dependencies for all the products.
Now, we only fetch logo and name (what we display), then fetch the details once the product has been selected