### PR TITLE
[MNOE-1031] Fix orgs table when no user

### DIFF
--- a/src/app/components/mnoe-organizations-local-list/mnoe-organizations-local-list.coffee
+++ b/src/app/components/mnoe-organizations-local-list/mnoe-organizations-local-list.coffee
@@ -11,7 +11,8 @@
   },
   templateUrl: 'app/components/mnoe-organizations-local-list/mnoe-organizations-local-list.html',
   link: (scope, elem, attrs) ->
-
+    # Only display some info in the context of an user
+    scope.userContext = attrs.user?
     scope.userRoles = UserRoles
     # Variables initialization
     scope.organizations =

--- a/src/app/components/mnoe-organizations-local-list/mnoe-organizations-local-list.html
+++ b/src/app/components/mnoe-organizations-local-list/mnoe-organizations-local-list.html
@@ -9,7 +9,7 @@
         <tr>
           <th translate>mnoe_admin_panel.dashboard.organization.widget.local_list.search_organizations.table.name</th>
           <th style="width: 100px;" translate>mnoe_admin_panel.dashboard.organization.widget.local_list.search_organizations.table.created_at</th>
-          <th style="width: 130px;" translate>mnoe_admin_panel.dashboard.organization.widget.local_list.search_organizations.table.role</th>
+          <th style="width: 130px;" ng-if="userContext" translate>mnoe_admin_panel.dashboard.organization.widget.local_list.search_organizations.table.role</th>
         </tr>
       </thead>
       <tbody>
@@ -22,7 +22,7 @@
             </a>
           </td>
           <td>{{organization.created_at | date: 'dd/MM/yyyy'}}</td>
-          <td>
+          <td ng-if="userContext">
             <select ng-show="organization.editMode" ng-model="organization.role" ng-options="role.value as role.translatedLabel for role in userRoles.availableRolesForOptions"></select>
             <span ng-show="organization.isUpdatingRole"><i class="fa fa-spinner fa-pulse fa-fw"></i></span>
             <span ng-click="editRole(organization)" ng-hide="organization.editMode">{{ userRoles.keyFromRole(organization.role) | translate }}</span>

--- a/src/app/components/mnoe-users-local-list/mnoe-users-local-list.coffee
+++ b/src/app/components/mnoe-users-local-list/mnoe-users-local-list.coffee
@@ -12,7 +12,7 @@
   templateUrl: 'app/components/mnoe-users-local-list/mnoe-users-local-list.html',
   link: (scope, elem, attrs) ->
     scope.isImpersonationEnabled = MnoeAdminConfig.isImpersonationEnabled()
-    # Only some info in the context of an organization
+    # Only display some info in the context of an organization
     scope.organizationContext = attrs.organization?
     scope.userRoles = UserRoles
     scope.editMode = false


### PR DESCRIPTION
Only display the role column when in the context of an user.
This was breaking the customer import as the orgs are displayed without an user.

Same ass #176 but for the other table