### PR TITLE
[OPALSUP-75] Hide App selection when provisioning enabled

### DIFF
--- a/src/app/views/customers/create-step-1/create-step-1.controller.coffee
+++ b/src/app/views/customers/create-step-1/create-step-1.controller.coffee
@@ -5,6 +5,9 @@
   vm.organization = {}
   vm.appSearch = ""
 
+  # The app selection is not compatible with the subscription workflow
+  vm.showAppsSelection = MnoeAdminConfig.isAppManagementEnabled() && !MnoeAdminConfig.isProvisioningEnabled()
+
   vm.toggleApp = (app) ->
     app.checked = !app.checked
 
@@ -27,7 +30,7 @@
     MnoErrorsHandler.resetErrors(vm.form)
 
     # List of checked apps
-    vm.organization.app_nids = _.map(_.filter(vm.marketplace.apps, {checked: true}), 'nid') if MnoeAdminConfig.isAppManagementEnabled()
+    vm.organization.app_nids = _.map(_.filter(vm.marketplace.apps, {checked: true}), 'nid') if vm.showAppsSelection
 
     MnoeOrganizations.create(vm.organization).then(
       (response) ->
@@ -50,6 +53,6 @@
     (response) ->
       # Copy the marketplace as we will work on the cached object
       vm.marketplace = angular.copy(response.data)
-  ) if MnoeAdminConfig.isAppManagementEnabled()
+  ) if vm.showAppsSelection
 
   return

--- a/src/app/views/customers/create-step-1/create-step-1.html
+++ b/src/app/views/customers/create-step-1/create-step-1.html
@@ -20,7 +20,7 @@
           </mno-widget-body>
         </mno-widget>
 
-        <mno-widget ng-if="::main.adminConfig.isAppManagementEnabled()" class="top-buffer-2" is-loading="!vm.marketplace" icon="fa-rocket" heading="{{'mnoe_admin_panel.dashboard.customers.create_customer.select_your_app' | translate}}">
+        <mno-widget ng-if="::vm.showAppsSelection" class="top-buffer-2" is-loading="!vm.marketplace" icon="fa-rocket" heading="{{'mnoe_admin_panel.dashboard.customers.create_customer.select_your_app' | translate}}">
           <mno-widget-header>
             <input type="text" ng-model="vm.appSearch" placeholder="{{'mnoe_admin_panel.dashboard.customers.create_customer.search' | translate}}" class="form-control input-sm search-bar">
           </mno-widget-header>


### PR DESCRIPTION
The App selection displayed during customer creation is no longer
compatible with the product workflow.