### PR TITLE
[OPALSUP-186] Hide aws contract fields

### DIFF
--- a/src/app/views/provisioning/details.controller.coffee
+++ b/src/app/views/provisioning/details.controller.coffee
@@ -1,17 +1,25 @@
-@App.controller('ProvisioningDetailsCtrl', ($scope, $q, $state, $stateParams, MnoeProvisioning, MnoeOrganizations, schemaForm, ProvisioningHelper, MnoeProducts, toastr) ->
+@App.controller('ProvisioningDetailsCtrl', ($scope, $q, $state, $stateParams, $filter, MnoeProvisioning, MnoeOrganizations, schemaForm, ProvisioningHelper, MnoeProducts, toastr) ->
   vm = this
   vm.subscription = MnoeProvisioning.getCachedSubscription()
 
   # We must use model schemaForm's sf-model, as #json_schema_opts are namespaced under model
   vm.model = vm.subscription.custom_data || {}
 
-  # Methods under the vm.model are used for calculated fields under #json_schema_opts.
+  # Methods under the vm.model are used for calculated fields under #json_schema_opts, which are set on third-party adapters.
   # Used to calculate the end date for forms with a contractEndDate.
   vm.model.calculateEndDate = (startDate, contractLength) ->
     return null unless startDate && contractLength
     moment(startDate)
     .add(contractLength.split('Months')[0], 'M')
     .format('YYYY-MM-DD')
+  # Used for forms that automatically calculate the startDate.
+  vm.model.timeNow = () ->
+    $filter('date')(new Date(), 'yyyy-MM-dd')
+
+  # Workaround. You can only specify defaults in the schema, and not the vm.form section.
+  # Since we are getting the schemas remotely, we must find a way to set defaults using vm.form.
+  vm.model.defaultContractLength = () ->
+    'monthly'
 
   urlParams =
     orgId: $stateParams.orgId,


### PR DESCRIPTION
I'm not a super big fan of this pattern -- adding a calculate method on the frontend, with it corresponding to a method under `product#json_schema` in the blue sky adapter. 

Changing this, however, would be difficult -- the only other way I can think is to define the methods as a string on the backend and then alter https://github.com/maestrano/angular-schema-form-calculate to use `#eval`, so it can evaluate that string. Using eval obviously isn't great either -- but it wouldn't be evaluating user input, but things we put in our database. 