### PR TITLE
 [MNOE-1218][MNOE-1219] Product pricings & Fix typo

### DIFF
--- a/src/app/views/products/product.controller.coffee
+++ b/src/app/views/products/product.controller.coffee
@@ -47,6 +47,9 @@
   vm.saveFreeTrial = -> update(['free_trial_enabled', 'free_trial_duration', 'free_trial_unit'])
 
   # Add a new pricing plan to edit to the list
+  # Note: Since language cannot be selected for local products
+  # it is set to 'en-GB' which is the default language for product pricings.
+  # This ensures all of the pricings will be returned to the frontend for local products.
   vm.addPricingPlan = ->
     vm.pricingPlan = {
       name: '',
@@ -56,7 +59,8 @@
       pricing_type: 'recurring',
       per_duration: '',
       per_unit: '',
-      prices: []
+      prices: [],
+      language: 'en-GB'
     }
     vm.currencies = _.clone(CURRENCIES.values)
     vm.product.product_pricings.push(vm.pricingPlan)

--- a/src/app/views/provisioning/details.controller.coffee
+++ b/src/app/views/provisioning/details.controller.coffee
@@ -19,7 +19,7 @@
   # Workaround. You can only specify defaults in the schema, and not the vm.form section.
   # Since we are getting the schemas remotely, we must find a way to set defaults using vm.form.
   vm.model.defaultContractLength = () ->
-    'monthly'
+    'Monthly'
 
   urlParams =
     orgId: $stateParams.orgId,


### PR DESCRIPTION
- Set language for all local product pricings to ensure that they are
all returned when viewing them in the marketplace
- Fix typo in provisioning workflow that prevented some contracts from
going through to their external provider.