### PR TITLE
[MNOE-1213] Fix staff role change confirmation

### DIFF
--- a/src/app/components/mnoe-api/admin/users.svc.coffee
+++ b/src/app/components/mnoe-api/admin/users.svc.coffee
@@ -1,5 +1,5 @@
 # Service for managing the users.
-@App.service 'MnoeUsers', ($q, $log, MnoeAdminApiSvc, MnoeObservables, OBS_KEYS) ->
+@App.service 'MnoeUsers', ($q, $log, MnoConfirm, MnoeAdminApiSvc, MnoeObservables, OBS_KEYS) ->
   _self = @
 
   @list = (limit, offset, sort, params = {}) ->

--- a/src/app/views/staff/staff.controller.coffee
+++ b/src/app/views/staff/staff.controller.coffee
@@ -55,8 +55,8 @@
           $log.error("An error occurred while updating staff:", error)
       ).finally(-> vm.isSaving = false)
 
-    if vm.staff.admin_role_was == 'staff' &&  vm.staff.admin_role != 'staff' && vm.staff.client_ids.length
-      # Ask for confirmation if the user is updated to admin or division admin as his clients will be cleared
+    # Ask for confirmation if the user is updated to admin or division admin as their clients will be cleared
+    if vm.staff.admin_role_was == 'staff' && vm.staff.admin_role != 'staff'
       modalOptions =
         closeButtonText: 'mnoe_admin_panel.dashboard.staff.update_staff_role.cancel'
         actionButtonText: 'mnoe_admin_panel.dashboard.staff.update_staff_role.action'

--- a/src/locales/en-AU.json
+++ b/src/locales/en-AU.json
@@ -904,7 +904,7 @@
   "mnoe_admin_panel.dashboard.staff.update_staff_role.cancel": "Cancel",
   "mnoe_admin_panel.dashboard.staff.update_staff_role.action": "Update Staff Role",
   "mnoe_admin_panel.dashboard.staff.update_staff_role.proceed": "Update Staff Role",
-  "mnoe_admin_panel.dashboard.staff.update_staff_role.perform": "Are you sure you want to change this staff role ? It will clear his clients.",
+  "mnoe_admin_panel.dashboard.staff.update_staff_role.perform": "Are you sure you want to change this staff role? This will clear their clients.",
   "mnoe_admin_panel.dashboard.sub_tenants.title": "Divisions",
   "mnoe_admin_panel.dashboard.sub_tenants.widget.list.loading": "Loading Divisions...",
   "mnoe_admin_panel.dashboard.sub_tenants.widget.list.title": "Divisions",


### PR DESCRIPTION
* Fix role change confirmation on staff page: Remove the check on the client size as it's no longer in the response and would require an external call.
* Add role change confirmation on staff list
* Improve the confirmation modal text