### PR TITLE
[OPAL-513] Locales displayed on "Validate"

### DIFF
--- a/src/app/views/provisioning/summary.controller.coffee
+++ b/src/app/views/provisioning/summary.controller.coffee
@@ -20,7 +20,7 @@
       vm.subscription = response.subscription
       vm.singleBilling = vm.subscription.product.single_billing_enabled
       vm.billedLocally = vm.subscription.product.billed_locally
-      vm.quoteBased = vm.subscription.product_pricing.quote_based
+      vm.quoteBased = vm.subscription.product_pricing?.quote_based
       vm.quote = MnoeProvisioning.getCachedQuote() if vm.quoteBased
   ).finally(-> vm.isLoading = false)
 


### PR DESCRIPTION
Add guarding to summary controller to prevent error when product is set
to skip plan selection.