### PR TITLE
[OPAL-437] Have feedback on product add

### DIFF
--- a/src/app/components/mno-product-selector/mno-product-selector.controller.coffee
+++ b/src/app/components/mno-product-selector/mno-product-selector.controller.coffee
@@ -51,7 +51,6 @@
         },
         'where[active]': true
       }
-      $ctrl.isLoadingProducts = true
 
       promise =
         switch $ctrl.flag
@@ -103,14 +102,14 @@
 
     # Close the modal and return the selected products
     $ctrl.closeModal = ->
-      $ctrl.isLoadingProducts = true
+      $ctrl.isLoadingSelectedProducts = true
       MnoeProvisioning.setSubscription({})
 
       promise = selectedProductsPromise()
       promise.then(
         (response) ->
           $ctrl.close({$value: response})
-      ).finally(-> $ctrl.isLoadingProducts = false)
+      ).finally(-> $ctrl.isLoadingSelectedProducts = false)
 
     $ctrl.dismissModal = ->
       $ctrl.dismiss()

--- a/src/app/components/mno-product-selector/mno-product-selector.html
+++ b/src/app/components/mno-product-selector/mno-product-selector.html
@@ -14,6 +14,7 @@
         </select>
       </div>
     </div>
+    <mno-loading-ellipsis ng-show="$ctrl.isLoadingProducts"></mno-loading-ellipsis>
     <div class="products-container">
       <div class="product-icon" ng-repeat="product in $ctrl.filteredProducts">
         <div class="product-icon-wrapper" ng-click="$ctrl.toggleProduct(product)" uib-tooltip="{{::product.name}}">
@@ -35,8 +36,8 @@
         <button ng-click="$ctrl.dismissModal()" class="btn btn-default" translate>
           mnoe_admin_panel.components.mno-product-selector.cancel
         </button>
-        <button ng-click="$ctrl.closeModal()" ng-disabled="$ctrl.selectedProducts.length === 0 || $ctrl.isLoadingProducts" class="btn btn-primary arrow">
-          <span ng-show="$ctrl.isLoadingProducts"><i class="fa fa-spinner fa-pulse fa-fw"></i></span>
+        <button ng-click="$ctrl.closeModal()" ng-disabled="$ctrl.selectedProducts.length === 0 || $ctrl.isLoadingSelectedProducts" class="btn btn-primary arrow">
+          <span ng-show="$ctrl.isLoadingSelectedProducts"><i class="fa fa-spinner fa-pulse fa-fw"></i></span>
           {{$ctrl.actionButtonText | translate}}
         </button>
       </div>

--- a/src/app/views/settings/apps/apps.controller.coffee
+++ b/src/app/views/settings/apps/apps.controller.coffee
@@ -1,4 +1,4 @@
-@App.controller 'SettingsAppsController', ($uibModal, MnoeMarketplace, MnoeApps, MnoeTenant, MnoConfirm, MnoeCurrentUser, UserRoles) ->
+@App.controller 'SettingsAppsController', ($uibModal, MnoeMarketplace, MnoeApps, MnoeTenant, MnoConfirm, MnoeCurrentUser, UserRoles, toastr) ->
   'ngInject'
   vm = this
 
@@ -73,9 +73,10 @@
     )
     modalInstance.result.then(
       (apps) ->
-        MnoeApps.enableMultiple(_.map(apps, 'id')).then(
-          ->
-            resetFilteredApps()
+        vm.isLoading = true
+        MnoeApps.enableMultiple(_.map(apps, 'id')).then(->
+          toastr.success('mnoe_admin_panel.dashboard.settings.apps.modal.add_app.toastr_success')
+          resetFilteredApps()
         )
     )
 

--- a/src/locales/en-AU.json
+++ b/src/locales/en-AU.json
@@ -143,6 +143,7 @@
   "mnoe_admin_panel.dashboard.settings.apps.available_apps": "Available Products",
   "mnoe_admin_panel.dashboard.settings.apps.modal.add_app.add": "Add products",
   "mnoe_admin_panel.dashboard.settings.apps.modal.add_app.title": "Add additional products",
+  "mnoe_admin_panel.dashboard.settings.apps.modal.add_app.toastr_success": "Additional products added to marketplace",
   "mnoe_admin_panel.dashboard.settings.apps.modal.remove_app.proceed": "Remove a product",
   "mnoe_admin_panel.dashboard.settings.apps.modal.remove_app.perform": "Do you really want to remove the product <b>{app_name}</b>?",
   "mno_enterprise.templates.settings.apps.modal.app_infos.description": "About {name}",


### PR DESCRIPTION
On adding a Hub product to a tenant, the product selection
dialog closed immediately and there was no feedback provided
to the user for 8+ seconds.

This change provides immediate feedback to the user by
clearing the existing products list and showing the loading
indicator. An interim toastr message confirms the products
are added.

A slight tweak to the loading of products within the selection
dialog box is also added for consistency.

@adamaziz15 I'm keen to get your feedback on how this looks.
I'm not hugely satisfied with how the feedback is provided -
the dialog box closes immediately which is inconsistent with how
the remove product dialog box works. If I went a bit further I could
instead keep the dialog box open (and not use the toastr message).