### PR TITLE
[MNOE-1279] Protect against null in product details

### DIFF
--- a/src/app/components/mno-product-selector/mno-product-selector.controller.coffee
+++ b/src/app/components/mno-product-selector/mno-product-selector.controller.coffee
@@ -80,17 +80,22 @@
       ).finally(-> $ctrl.isLoadingProducts = false)
 
     # Filter products by name or category
+    filterProducts = ->
+      if $ctrl.searchTerm?.length > 0
+        term = $ctrl.searchTerm.toLowerCase()
+        $ctrl.filteredProducts = (product for product in $ctrl.products when product.name?.toLowerCase().indexOf(term) > -1)
+      else if $ctrl.selectedCategory?.length > 0
+        $ctrl.filteredProducts = (product for product in $ctrl.products when $ctrl.selectedCategory in (product.categories || []))
+      else
+        $ctrl.filteredProducts = $ctrl.products
+
     $ctrl.onSearchChange = () ->
       $ctrl.selectedCategory = ''
-      term = $ctrl.searchTerm.toLowerCase()
-      $ctrl.filteredProducts = (product for product in $ctrl.products when product.name.toLowerCase().indexOf(term) isnt -1)
+      filterProducts()
 
     $ctrl.onCategoryChange = () ->
       $ctrl.searchTerm = ''
-      if ($ctrl.selectedCategory?.length > 0)
-        $ctrl.filteredProducts = (product for product in $ctrl.products when $ctrl.selectedCategory in product.categories)
-      else
-        $ctrl.filteredProducts = $ctrl.products
+      filterProducts()
 
     # Select or deselect a product
     $ctrl.toggleProduct = (product) ->


### PR DESCRIPTION
It is possible for product information to include null information,
including no name, or no categories. To protect against missing
information in the UI, don't presume search data exists. Filtering
now gracefully handles null.