### PR TITLE
[OPALSUP-305] Remove user from list-org list

### DIFF
--- a/src/app/components/mnoe-users-local-list/mnoe-users-local-list.coffee
+++ b/src/app/components/mnoe-users-local-list/mnoe-users-local-list.coffee
@@ -55,7 +55,7 @@
       # if view="last" is set on the directive, the last 10 users are displayed
       # if there is a search term, use that
       if scope.users.search.length > 0
-          setSearchUsersList()
+        setSearchUsersList()
       else if attrs.view == 'all'
         setAllUsersList()
       else if attrs.view == 'last'

--- a/src/app/components/mnoe-users-local-list/mnoe-users-local-list.html
+++ b/src/app/components/mnoe-users-local-list/mnoe-users-local-list.html
@@ -1,7 +1,7 @@
 <mno-widget icon="fa-user" heading="{{users.widgetTitle | translate:{length: list.length} }}" is-loading="!list">
   <mno-widget-header>
     &nbsp;<a href="" ng-click="switchState()" ng-show="list && users.switchLinkTitle" translate>{{users.switchLinkTitle}}</a>
-    <input type="text" ng-model="users.search" ng-change="searchChange()" placeholder="{{ 'mnoe_admin_panel.dashboard.users.widget.local_list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
+    <input type="text" ng-model="users.search" ng-change="updateDisplayState()" placeholder="{{ 'mnoe_admin_panel.dashboard.users.widget.local_list.search_users.placeholder.search_all' | translate}}" class="form-control input-sm search-bar" />
   </mno-widget-header>
   <mno-widget-body class="large-auto-height no-padding">
     <table class="table table-layout-fixed">

--- a/src/app/views/organization/create-user-modal/create-user.controller.coffee
+++ b/src/app/views/organization/create-user-modal/create-user.controller.coffee
@@ -8,7 +8,7 @@
     vm.isLoading = true
     MnoeUsers.addUser(organization, vm.user).then(
       (success) ->
-        toastr.success('mnoe_admin_panel.dashboard.organization.create_user.toastr_success', {extraData: {username: "#{vm.user.name} #{vm.user.surname}"}})
+        toastr.success('mnoe_admin_panel.dashboard.organization.create_user.toastr_success', {extraData: {username: "#{success.data.user.name} #{success.data.user.surname}"}})
         # Close the modal returning the item to the parent window
         $uibModalInstance.close(success.data.user)
       (error) ->


### PR DESCRIPTION
On removing a user from the organisation's list of members, update the
the source list, and then refilter the display list.

Refactored the search code for conciseness, and so it could be called
from the removal code.

Also tweaked the name displayed on successfully adding a user. If the
user already exists, the name will the be the existing record's user
name, not the one the user enters.