### PR TITLE
[OPALSUP-258] Reseller price plan not saved

### DIFF
--- a/src/app/views/products/product.controller.coffee
+++ b/src/app/views/products/product.controller.coffee
@@ -60,6 +60,9 @@
     }
     vm.currencies = _.clone(CURRENCIES.values)
     vm.product.product_pricings.push(vm.pricingPlan)
+    # Set current plan id to true since there is no id for
+    # a plan that has not been saved.
+    vm.currentPricingPlanId = true
 
   vm.editPricingPlan = (pricingPlan) ->
     # Check that a pricing plan is not already being edited

--- a/src/app/views/products/product.html
+++ b/src/app/views/products/product.html
@@ -70,7 +70,7 @@
         </mno-section>
 
         <mno-section id="plans" heading="{{'mnoe_admin_panel.dashboard.product.pricing_plans' | translate}}">
-          <button class="btn btn-link bottom-buffer-1" ng-click="vm.addPricingPlan()">
+          <button class="btn btn-link bottom-buffer-1" ng-click="vm.addPricingPlan()" ng-disabled="vm.currentPricingPlanId">
             <i class="fa fa-plus"></i> {{'mnoe_admin_panel.dashboard.product.add_pricing_plan' | translate}}
           </button>
           <ul class="list-group" ng-model="vm.product.product_pricings">


### PR DESCRIPTION
Update product view to only allow one pricing plan at a time to be in an edit state.