### PR TITLE
[KAPP-175] Add readOnly staff feature flag

### DIFF
--- a/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
+++ b/src/app/components/mnoe-config/mnoe-admin-config.svc.coffee
@@ -33,6 +33,13 @@
     else
       true
 
+  # RO staff (still allow for customer assignment)
+  @isStaffReadOnly = () ->
+    if ADMIN_PANEL_CONFIG.staff?
+      ADMIN_PANEL_CONFIG.staff.read_only
+    else
+      false
+
   @isFinanceEnabled = () ->
     if ADMIN_PANEL_CONFIG.finance?
       ADMIN_PANEL_CONFIG.finance.enabled

--- a/src/app/components/mnoe-staffs-list/mnoe-staffs-list.coffee
+++ b/src/app/components/mnoe-staffs-list/mnoe-staffs-list.coffee
@@ -3,6 +3,9 @@
 #
 @App.component('mnoeStaffsList', {
   templateUrl: 'app/components/mnoe-staffs-list/mnoe-staffs-list.html',
+  bindings: {
+    readOnly: '@'
+  }
   controller: ($filter, $log, MnoeUsers, MnoeCurrentUser, MnoConfirm, MnoeObservables, MnoeAdminConfig, OBS_KEYS, toastr) ->
     vm = this
 

--- a/src/app/components/mnoe-staffs-list/mnoe-staffs-list.html
+++ b/src/app/components/mnoe-staffs-list/mnoe-staffs-list.html
@@ -12,8 +12,8 @@
             <th st-sort="email" class="col-lg-3" translate>mnoe_admin_panel.dashboard.staffs.widget.list.table.email</th>
             <th st-sort="created_at" class="col-lg-2" translate>mnoe_admin_panel.dashboard.staffs.widget.list.table.created_at</th>
             <th st-sort="admin_role" class="col-lg-3" translate>mnoe_admin_panel.dashboard.staffs.widget.list.table.role</th>
-            <th></th>
-            <th></th>
+            <th ng-if="!$ctrl.readOnly"></th>
+            <th ng-if="!$ctrl.readOnly"></th>
         	</tr>
         	<tr>
             <th>
@@ -32,8 +32,8 @@
                 <option value="{{role.value}}" ng-repeat="role in $ctrl.staff.roles">{{ role.label | translate }}</option>
               </select>
             </th>
-            <th></th>
-            <th></th>
+            <th ng-if="!$ctrl.readOnly"></th>
+            <th ng-if="!$ctrl.readOnly"></th>
         	</tr>
       	</thead>
         <tbody ng-show="$ctrl.staff.loading">
@@ -52,12 +52,12 @@
                 <option ng-repeat="role in $ctrl.staff.roles" value="{{role.value}}">{{role.label | translate}}</option>
               </select>
             </td>
-            <td>
+            <td ng-if="!$ctrl.readOnly">
               <div ng-hide="$ctrl.staff.oneAdminLeft && staffElem.admin_role == 'admin'">
                 <a href="" ng-hide="$ctrl.staff.editmode[staffElem.id]" ng-click="$ctrl.staff.editmode[staffElem.id] = true"><i class="fa fa-pencil"></i></a>
               </div>
             </td>
-            <td>
+            <td ng-if="!$ctrl.readOnly">
               <div ng-hide="$ctrl.staff.oneAdminLeft && staffElem.admin_role == 'admin'">
                 <a href="" ng-hide="$ctrl.staff.editmode[staffElem.id]" ng-click="$ctrl.staff.remove(staffElem)"><i class="fa fa-times"></i></a>
               </div>

--- a/src/app/views/staff/staff.controller.coffee
+++ b/src/app/views/staff/staff.controller.coffee
@@ -10,6 +10,7 @@
 
   vm.isSubTenantEnabled = MnoeAdminConfig.isSubTenantEnabled()
   vm.isAccountManagerEnabled = MnoeAdminConfig.isAccountManagerEnabled()
+  vm.isStaffReadOnly = MnoeAdminConfig.isStaffReadOnly()
 
   # Get the user
   MnoeUsers.get($stateParams.staffId).then(

--- a/src/app/views/staff/staff.html
+++ b/src/app/views/staff/staff.html
@@ -11,13 +11,13 @@
         <div class="bs-row row">
           <div class="col-md-3"><div class="label-cell" translate>mnoe_admin_panel.dashboard.staff.name</div></div>
           <div class="col-md-3">
-            <input type="text" class="form-control input-sm" ng-model="vm.staff.name" required>
+            <input type="text" class="form-control input-sm" ng-model="vm.staff.name" ng-disabled="vm.isStaffReadOnly" required>
           </div>
         </div>
         <div class="bs-row row">
           <div class="col-md-3"><div class="label-cell" translate>mnoe_admin_panel.dashboard.staff.surname</div></div>
           <div class="col-md-3">
-            <input type="text" class="form-control input-sm" ng-model="vm.staff.surname" required>
+            <input type="text" class="form-control input-sm" ng-model="vm.staff.surname" ng-disabled="vm.isStaffReadOnly" required>
           </div>
         </div>
         <div class="bs-row row">
@@ -28,7 +28,7 @@
           <div class="col-sm-3"><div class="label-cell" translate>mnoe_admin_panel.dashboard.staff.admin_role</div></div>
           <div class="col-md-3">
             <span ng-if="!vm.isAdmin">{{vm.staff.adminRoleName() | translate}}</span>
-            <select ng-model="vm.staff.admin_role" ng-if="vm.isAdmin" class="form-control input-sm">
+            <select ng-model="vm.staff.admin_role" ng-if="vm.isAdmin" ng-disabled="vm.isStaffReadOnly" class="form-control input-sm">
               <option value="{{role.value}}" ng-repeat="role in vm.adminRoles">{{ role.label | translate }}</option>
             </select>
           </div>
@@ -51,7 +51,7 @@
             </select>
           </div>
         </div>
-        <div class="bs-row row">
+        <div class="bs-row row" ng-if="!vm.isStaffReadOnly">
           <div class="col-sm-3">
             <button class="btn btn-primary" ng-show="vm.staff" ng-disabled="vm.isSaving" ng-click="vm.updateStaff()" translate>
               <span ng-show="vm.isSaving"><i class="fa fa-spinner fa-pulse fa-fw"></i></span>

--- a/src/app/views/staffs/staffs.controller.coffee
+++ b/src/app/views/staffs/staffs.controller.coffee
@@ -1,6 +1,8 @@
-@App.controller 'StaffsController', ($filter, $stateParams, $uibModal) ->
+@App.controller 'StaffsController', ($filter, $stateParams, $uibModal, MnoeAdminConfig) ->
   'ngInject'
   vm = this
+
+  vm.isStaffReadOnly = MnoeAdminConfig.isStaffReadOnly()
 
   vm.staff =
     # Display staff creation modal

--- a/src/app/views/staffs/staffs.html
+++ b/src/app/views/staffs/staffs.html
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row" ng-if="!vm.isStaffReadOnly">
   <div class="col-xs-8 col-lg-offset-1 top-buffer-1">
     <button role="button" ng-click="vm.staff.createModal()" class="btn btn-primary" translate>
       mnoe_admin_panel.dashboard.staffs.add_staff
@@ -8,6 +8,6 @@
 
 <div class="row">
   <div class="col-lg-10 col-lg-offset-1 col-md-12">
-    <mnoe-staffs-list view="all"></mnoe-staffs-list>
+    <mnoe-staffs-list read-only="{{vm.isStaffReadOnly}}"></mnoe-staffs-list>
   </div>
 </div>


### PR DESCRIPTION
Add a new feature flag (disabled by default) which allow to disable staff edition.

This is useful when the staff list is managed through an external system via API.

Note that the client assignment is still possible (this is controlled by another feature flag)

## Screenshots

### Read Write
![all_staffs_rw](https://user-images.githubusercontent.com/19894/54902227-ed4e5580-4f2c-11e9-98b6-83cd6a368cc5.png)
![staff_view_rw](https://user-images.githubusercontent.com/19894/54902229-ef181900-4f2c-11e9-967b-034261d395a7.png)

### Read Only
![all_staffs_ro](https://user-images.githubusercontent.com/19894/54902259-ff2ff880-4f2c-11e9-8269-bb2510589b15.png)
![staff_view_ro](https://user-images.githubusercontent.com/19894/54902264-00f9bc00-4f2d-11e9-83f9-24fe3d6d80d5.png)

