### PR TITLE
[KAPP-181] Enable multi-company staff dashboard

### DIFF
--- a/src/app/components/mnoe-staff-dashboards-list/mnoe-staff-dashboards-list.coffee
+++ b/src/app/components/mnoe-staff-dashboards-list/mnoe-staff-dashboards-list.coffee
@@ -89,8 +89,6 @@
     # Advisor Dashboard
     # -----------------------------------------------------------
     vm.createDashboard = (dashboard) ->
-      angular.merge(dashboard, { organization_ids: [vm.organization.id] })
-
       # TODO: bug when creating after copying (also present on frontend)
       promise = if dashboard.id
         ImpacDashboardsSvc.copy(dashboard)

--- a/src/app/impac.config.coffee
+++ b/src/app/impac.config.coffee
@@ -33,6 +33,7 @@ angular.module 'frontendAdmin'
       linkUrl: '#!/marketplace'
       linkTarget: '_self'
     dhbConfig:
+      multiCompany: true
       designerMode:
         enabled: true
         dhbLabelName: 'Template'

--- a/src/app/impac.config.coffee
+++ b/src/app/impac.config.coffee
@@ -33,7 +33,6 @@ angular.module 'frontendAdmin'
       linkUrl: '#!/marketplace'
       linkTarget: '_self'
     dhbConfig:
-      multiCompany: true
       designerMode:
         enabled: true
         dhbLabelName: 'Template'

--- a/src/app/services/impac-config/impac-config.coffee
+++ b/src/app/services/impac-config/impac-config.coffee
@@ -88,6 +88,8 @@
     # Configure Dashboard Designer
     options =
       dhbConfig:
+        # Do not enable multi company templates
+        multiCompany: !enabled
         designerMode:
           enabled: enabled
       # For now do not allow to create templates from templates

--- a/src/app/services/impac-config/impac-config.coffee
+++ b/src/app/services/impac-config/impac-config.coffee
@@ -1,4 +1,4 @@
-@App.service 'ImpacConfigSvc' , ($state, $stateParams, $log, $q, MnoeCurrentUser, MnoeOrganizations, ImpacMainSvc, ImpacRoutes, ImpacTheming, IMPAC_CONFIG) ->
+@App.service 'ImpacConfigSvc' , ($state, $stateParams, $log, $q, MnoeAdminConfig, MnoeCurrentUser, MnoeOrganizations, ImpacMainSvc, ImpacRoutes, ImpacTheming, IMPAC_CONFIG) ->
   _self = @
 
   # Keep track of dashboard designer mode
@@ -40,15 +40,23 @@
       # Temporary cache the promise and clear the cache when resolved
       # This avoid multiple call to @getOrganizations generating multiple promises in parallel (and API calls)
       # We clear the cache at resolution so we don't have stall data and that's enough to avoid extra API query
-      _self.orgPromises[parseInt($stateParams.orgId)] ||= MnoeOrganizations.get($stateParams.orgId).then(
-        (response) ->
-          currentOrganization = response.data.plain()
-          angular.extend(currentOrganization, {acl: defaultACL})
-          _self.orgPromises[parseInt($stateParams.orgId)] = null
-          $q.resolve(
-            organizations: [currentOrganization],
-            currentOrgId: currentOrganization.id
-          )
+      _self.orgPromises[parseInt($stateParams.orgId)] ||= MnoeCurrentUser.getUser().then( ->
+        params = if MnoeAdminConfig.isAccountManagerEnabled()
+          {sub_tenant_id: MnoeCurrentUser.user.mnoe_sub_tenant_id, account_manager_id: MnoeCurrentUser.user.id}
+        else
+          {}
+
+        # TODO: problem with pagination (only returns first 30 orgs)
+        # Would need rework of the create-dashboard modal in impac-angular
+        MnoeOrganizations.list(30, 0, 'name', params).then(
+          (response) ->
+            organizations = (angular.extend(org, {acl: defaultACL}) for org in response.data)
+            _self.orgPromises[parseInt($stateParams.orgId)] = null
+            $q.resolve(
+              organizations: organizations,
+              currentOrgId: parseInt($stateParams.orgId)
+            )
+        )
       )
     else
       $log.warn('ImpacConfigSvc.getOrganizations: Designer disabled and orgId specified')


### PR DESCRIPTION
Known issue: only returns the first page of companies.
We would need to rework the create dashboard modal to be able to handle pagination.

This enable multi-company mode on the staff dashboard.
* Enable the impac-angular feature flag only on staff dashboard view (not in the designer view)
* Modify the impac-angular configuration service to inject organisations accessible by the current staff (previously we were only loading the current organisation)