### PR TITLE
[KAPP-186] Add organization selector in the staff dashboard view

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,8 @@
     "angular-sanitize": "^1.6.2",
     "angular-message-format": "^1.6.2",
     "impac-angular": "~1.8.5",
-    "angular-bootstrap-toggle": "^0.1.2"
+    "angular-bootstrap-toggle": "^0.1.2",
+    "angular-ui-select": "^0.19.8"
   },
   "devDependencies": {
     "angular-mocks": "~1.6.2"

--- a/src/app/components/mnoe-organization-selector/mnoe-organization-selector.coffee
+++ b/src/app/components/mnoe-organization-selector/mnoe-organization-selector.coffee
@@ -1,0 +1,68 @@
+#
+# Mnoe Organization Selector
+#
+# Display the list of Organization available to a staff member and allow to switch between them
+# while on the staff dashboard view
+#
+@App.component('mnoeOrganizationSelector', {
+  templateUrl: 'app/components/mnoe-organization-selector/mnoe-organization-selector.html',
+  bindings: {
+    organizationId: '<'
+  }
+  controller: ($log, $state, MnoeAdminConfig, MnoeCurrentUser, MnoeOrganizations) ->
+    ctrl = this
+
+    ctrl.refreshOrganizations = (search = null) ->
+      search = search.toLowerCase()
+
+      # Filtering by Account Manager
+      params = if MnoeAdminConfig.isAccountManagerEnabled()
+        {sub_tenant_id: MnoeCurrentUser.user.mnoe_sub_tenant_id, account_manager_id: MnoeCurrentUser.user.id}
+      else
+        {}
+
+      # Search terms
+      if search
+        params['terms'] = {'name.like': "%#{search}%"}
+
+      args = [10, 0, 'name', params]
+
+      MnoeOrganizations.list(args...).then(
+        (response) ->
+          ctrl.organizations.totalItems = response.headers('x-total-count')
+          ctrl.organizations.list = response.data
+
+          # TODO: refactor this
+          # Select organization
+          if (orgId = parseInt(ctrl.organizationId))
+            $log.info('Trying to select org')
+            ctrl.organizations.selected = ctrl.organizations.list.find(
+              (org) ->
+                $log.info(org.id, orgId)
+                org.id == orgId
+            )
+            # If current organization not available in first page, manually fetch it
+            # Unless a search is in progress
+            unless ctrl.organizations.selected || search
+              $log.info('Organization not available in page, fetching it')
+              MnoeOrganizations.list(
+                1, 0, 'name', angular.extend({terms: {id: orgId}}, params)
+              ).then(
+                (response) ->
+                  if (org = response.data[0])
+                    ctrl.organizations.list.unshift(org)
+                    ctrl.organizations.selected = org
+              )
+      )
+
+    ctrl.onSelectCallback = (item, _model) ->
+      # Display the staff dashboards for the selected company
+      $state.go('dashboard.staff-dashboard-show', {orgId: item.id, dashboardId: null})
+
+    # Variables initialization
+    ctrl.organizations =
+      list: []
+      loading: false
+
+    return
+})

--- a/src/app/components/mnoe-organization-selector/mnoe-organization-selector.coffee
+++ b/src/app/components/mnoe-organization-selector/mnoe-organization-selector.coffee
@@ -9,7 +9,7 @@
   bindings: {
     organizationId: '<'
   }
-  controller: ($log, $state, MnoeAdminConfig, MnoeCurrentUser, MnoeOrganizations) ->
+  controller: ($state, MnoeAdminConfig, MnoeCurrentUser, MnoeOrganizations) ->
     ctrl = this
 
     ctrl.refreshOrganizations = (search = null) ->
@@ -35,16 +35,11 @@
           # TODO: refactor this
           # Select organization
           if (orgId = parseInt(ctrl.organizationId))
-            $log.info('Trying to select org')
-            ctrl.organizations.selected = ctrl.organizations.list.find(
-              (org) ->
-                $log.info(org.id, orgId)
-                org.id == orgId
-            )
+            ctrl.organizations.selected = ctrl.organizations.list.find((org) -> org.id == orgId)
+
             # If current organization not available in first page, manually fetch it
             # Unless a search is in progress
             unless ctrl.organizations.selected || search
-              $log.info('Organization not available in page, fetching it')
               MnoeOrganizations.list(
                 1, 0, 'name', angular.extend({terms: {id: orgId}}, params)
               ).then(

--- a/src/app/components/mnoe-organization-selector/mnoe-organization-selector.coffee
+++ b/src/app/components/mnoe-organization-selector/mnoe-organization-selector.coffee
@@ -25,7 +25,7 @@
       if search
         params['terms'] = {'name.like': "%#{search}%"}
 
-      args = [10, 0, 'name', params]
+      args = [30, 0, 'name', params]
 
       MnoeOrganizations.list(args...).then(
         (response) ->

--- a/src/app/components/mnoe-organization-selector/mnoe-organization-selector.html
+++ b/src/app/components/mnoe-organization-selector/mnoe-organization-selector.html
@@ -1,0 +1,21 @@
+<form class="form-inline">
+  <div class="form-group">
+    <ui-select
+      ng-model="$ctrl.organizations.selected"
+      append-to-body="true"
+      on-select="$ctrl.onSelectCallback($item, $model)"
+      spinner-enabled="true"
+    >
+      <ui-select-match placeholder="Select a customer">
+        <span ng-bind="$select.selected.name"></span>
+      </ui-select-match>
+      <ui-select-choices
+        repeat="org in $ctrl.organizations.list track by org.id"
+        refresh="$ctrl.refreshOrganizations($select.search)"
+        refresh-delay="300"
+      >
+        <div ng-bind-html="org.name | highlight: $select.search"></div>
+      </ui-select-choices>
+    </ui-select>
+  </div>
+</form>

--- a/src/app/components/mnoe-organization-selector/mnoe-organization-selector.html
+++ b/src/app/components/mnoe-organization-selector/mnoe-organization-selector.html
@@ -1,8 +1,7 @@
-<form class="form-inline">
+<form class="form-horizontal">
   <div class="form-group">
     <ui-select
       ng-model="$ctrl.organizations.selected"
-      append-to-body="true"
       on-select="$ctrl.onSelectCallback($item, $model)"
       spinner-enabled="true"
     >

--- a/src/app/index.less
+++ b/src/app/index.less
@@ -135,6 +135,12 @@ table {
   z-index: 999;
 }
 
+// Fix issue with ui-select dropdown
+// append-to-body didn't seem to work when minified
+mno-admin {
+  overflow-x: initial;
+}
+
 /**
  *  Do not remove the comments below. It's the markers used by gulp-inject to inject
  *  all your less files automatically

--- a/src/app/index.module.coffee
+++ b/src/app/index.module.coffee
@@ -22,5 +22,6 @@
   'pascalprecht.translate',
   'ngSanitize',
   'maestrano.impac',
-  'ui.toggle'
+  'ui.toggle',
+  'ui.select'
 ]

--- a/src/app/index.route.coffee
+++ b/src/app/index.route.coffee
@@ -179,7 +179,7 @@
     $stateProvider.state 'dashboard.staff-dashboard-show',
       data:
         dashboardDesigner: false
-      url: '^/organization/:orgId/staff-dashboard/:dashboardId'
+      url: '^/organization/:orgId/staff-dashboards/:dashboardId'
       templateUrl: 'app/views/impac/impac.html'
       controller: 'ImpacController'
       controllerAs: 'vm'

--- a/src/app/services/impac-config/impac-config.coffee
+++ b/src/app/services/impac-config/impac-config.coffee
@@ -5,13 +5,13 @@
   _self.dashboardDesigner = null
 
   # Used to control Impac Angular UI in staff dashboard mode
-  # We want to remove the create/delete dashboard butttons as this is managed through
+  # We want to remove the delete dashboard button as this is managed through
   # the staff-dashboard-list component.
   defaultACL = {
     self: {show: true, update: true, destroy: true},
     related: {
       impac: {show: true},
-      dashboards: {show: true, create: false, update: true, destroy: false},
+      dashboards: {show: true, create: true, update: true, destroy: false},
       widgets: {show: true, create: true, update: true, destroy: true},
       kpis: {show: false, create: false, update: false, destroy: false}
     }

--- a/src/app/views/impac/impac.coffee
+++ b/src/app/views/impac/impac.coffee
@@ -18,7 +18,9 @@
     (loaded) ->
       if loaded
         dashboardId = parseInt($stateParams.dashboardId)
-        ImpacDashboardsSvc.setCurrentDashboard(dashboardId)
+        # Select the dashboard specified in the URL
+        # If none specified, Impac will select the first one
+        ImpacDashboardsSvc.setCurrentDashboard(dashboardId) if dashboardId
         vm.currentDashboard = ImpacDashboardsSvc.getCurrentDashboard()
   )
 

--- a/src/app/views/impac/impac.html
+++ b/src/app/views/impac/impac.html
@@ -1,4 +1,4 @@
-<div id="impac">
+<div id="impac" ng-class="{ 'designer': vm.designerMode }">
   <div class="row top-navigation" ng-switch="vm.designerMode">
     <div class="col-md-6">
       <a class="back" ui-sref="dashboard.dashboard-templates" ng-switch-when="true">

--- a/src/app/views/impac/impac.html
+++ b/src/app/views/impac/impac.html
@@ -1,13 +1,19 @@
 <div id="impac">
-  <div class="top-navigation" ng-switch="vm.designerMode">
-    <a class="back" ui-sref="dashboard.dashboard-templates" ng-switch-when="true">
-      &lt;&lt; {{ 'mnoe_admin_panel.dashboard.dashboard_templates.back_link' | translate }}
-    </a>
-    <a class="back" ui-sref="dashboard.customers.organization({orgId: vm.orgId})" ng-switch-when="false">
-      &lt;&lt; {{ 'mnoe_admin_panel.dashboard.staff_dashboards.back_link' | translate }}
-    </a>
+  <div class="row top-navigation" ng-switch="vm.designerMode">
+    <div class="col-md-6">
+      <a class="back" ui-sref="dashboard.dashboard-templates" ng-switch-when="true">
+        &lt;&lt; {{ 'mnoe_admin_panel.dashboard.dashboard_templates.back_link' | translate }}
+      </a>
+      <a class="back" ui-sref="dashboard.customers.organization({orgId: vm.orgId})" ng-switch-when="false">
+        &lt;&lt; {{ 'mnoe_admin_panel.dashboard.staff_dashboards.back_link' | translate }}
+      </a>
+    </div>
 
-    <toggle class="pull-right" ng-if="vm.designerMode" ng-show="vm.currentDashboard" ng-model="vm.currentDashboard.published" ng-change="vm.toggleTemplatePublished(vm.currentDashboard.id)" on="{{ 'mnoe_admin_panel.dashboard.dashboard_templates.published' | translate }}" off="{{ 'mnoe_admin_panel.dashboard.dashboard_templates.draft' | translate }}" uib-tooltip="{{ 'mnoe_admin_panel.dashboard.dashboard_templates.published_state_tooltip' | translate }}"></toggle>
+    <div class="col-md-6">
+      <toggle class="pull-right" ng-if="vm.designerMode" ng-show="vm.currentDashboard" ng-model="vm.currentDashboard.published" ng-change="vm.toggleTemplatePublished(vm.currentDashboard.id)" on="{{ 'mnoe_admin_panel.dashboard.dashboard_templates.published' | translate }}" off="{{ 'mnoe_admin_panel.dashboard.dashboard_templates.draft' | translate }}" uib-tooltip="{{ 'mnoe_admin_panel.dashboard.dashboard_templates.published_state_tooltip' | translate }}"></toggle>
+
+      <mnoe-organization-selector organization-id="vm.orgId" class="pull-right" ng-if="!vm.designerMode"></mnoe-organization-selector>
+    </div>
   </div>
 
   <impac-dashboard />

--- a/src/app/views/impac/impac.html
+++ b/src/app/views/impac/impac.html
@@ -9,10 +9,10 @@
       </a>
     </div>
 
-    <div class="col-md-6">
+    <div class="col-sm-3 col-sm-offset-3">
       <toggle class="pull-right" ng-if="vm.designerMode" ng-show="vm.currentDashboard" ng-model="vm.currentDashboard.published" ng-change="vm.toggleTemplatePublished(vm.currentDashboard.id)" on="{{ 'mnoe_admin_panel.dashboard.dashboard_templates.published' | translate }}" off="{{ 'mnoe_admin_panel.dashboard.dashboard_templates.draft' | translate }}" uib-tooltip="{{ 'mnoe_admin_panel.dashboard.dashboard_templates.published_state_tooltip' | translate }}"></toggle>
 
-      <mnoe-organization-selector organization-id="vm.orgId" class="pull-right" ng-if="!vm.designerMode"></mnoe-organization-selector>
+      <mnoe-organization-selector organization-id="vm.orgId" ng-if="!vm.designerMode"></mnoe-organization-selector>
     </div>
   </div>
 

--- a/src/app/views/impac/impac.less
+++ b/src/app/views/impac/impac.less
@@ -9,31 +9,8 @@
   
   .analytics {
     padding-top: 0;
-    margin-left: 0px;
 
     #module__dashboard-selector {
-      .dashboard-title {
-        div[role="button"] {
-          cursor: default;
-          outline: none;
-        }
-        i.fa.fa-pencil {
-          margin: 0 !important;
-          padding-left: 20px;
-          cursor: pointer;
-          outline: none;
-        }
-        .fa.fa-chevron-down { display: none; }
-      }
-
-      .dashboard-select {
-        display: none;
-      }
-
-      .data-source-label {
-        display: none;
-      }
-
       // Overrides bootstrap no-gutters for the dashboard's top-bar
       .row.buttons-bar-row.buttons-bar.no-gutters {
         margin-left: -15px;
@@ -59,12 +36,7 @@
 
     .widget-item {
       display:block !important;
-      .top-buttons {
-        .top-button.btn-refresh { display: none; }
-      }
-      .edit {
-        .part[setting-organizations] { display: none; }
-      }
+
       .data-not-found {
         .message {
           font-size: 12px;
@@ -86,5 +58,47 @@
       }
     }
 
+  }
+}
+
+// Used to customised UI for designer mode
+// TODO: this should be done in impac-angular with the feature flag,
+// For now, just move previous customisation to this class
+#impac.designer {
+  .analytics {
+    #module__dashboard-selector {
+      .dashboard-title {
+        div[role="button"] {
+          cursor: default;
+          outline: none;
+        }
+        i.fa.fa-pencil {
+          margin: 0 !important;
+          padding-left: 20px;
+          cursor: pointer;
+          outline: none;
+        }
+        .fa.fa-chevron-down { display: none; }
+      }
+
+      .dashboard-select {
+        display: none;
+      }
+
+      .data-source-label {
+        display: none;
+      }
+    }
+
+    .widget-item {
+      .top-buttons {
+        .top-button.btn-refresh {
+          display: none;
+        }
+      }
+      .edit {
+        .part[setting-organizations] { display: none; }
+      }
+    }
   }
 }


### PR DESCRIPTION
Add an organization selector to the staff dashboard view to allow a staff to easily switch between its customers.

This also contains some improvements:
* Fix multiple concurrent retrievals of organization
* Improve Impac! CSS to be different for staff dashboard and designer mode.
* Some UI changes on Impac! to allow switching dashboard in the staff dashboard view

**Demo**
![dashboard_selector](https://user-images.githubusercontent.com/19894/56872374-bc050000-6a6b-11e9-8275-f0f5cfe366f8.gif)
