### PR TITLE
[KAPP-184] Fix dashboard printing

### DIFF
--- a/src/app/stylesheets/print.less
+++ b/src/app/stylesheets/print.less
@@ -2,4 +2,8 @@
   li.sidebar-main {
     display: none;
   }
+
+  mno-admin #content-wrapper {
+    overflow-x: visible;
+  }
 }


### PR DESCRIPTION
Change overflow to avoid cropping dashboard when printing.

This fix the bug when only the first page of the dashboard is printed.