### PR TITLE
[KAPP-187] Fix dashboard creation

### DIFF
--- a/src/app/components/mnoe-organizations-list/mnoe-organizations-list.coffee
+++ b/src/app/components/mnoe-organizations-list/mnoe-organizations-list.coffee
@@ -27,6 +27,7 @@
     fetchOrganizations = (limit, offset, sort = 'name') ->
       scope.organizations.loading = true
       MnoeCurrentUser.getUser().then( ->
+        # TODO: no longer needed with latest mnoe 3.4
         params = if MnoeAdminConfig.isAccountManagerEnabled()
           {sub_tenant_id: MnoeCurrentUser.user.mnoe_sub_tenant_id, account_manager_id: MnoeCurrentUser.user.id}
         else

--- a/src/app/components/mnoe-staff-dashboards-list/mnoe-staff-dashboards-list.coffee
+++ b/src/app/components/mnoe-staff-dashboards-list/mnoe-staff-dashboards-list.coffee
@@ -89,7 +89,6 @@
     # Advisor Dashboard
     # -----------------------------------------------------------
     vm.createDashboard = (dashboard) ->
-      # TODO: bug when creating after copying (also present on frontend)
       promise = if dashboard.id
         ImpacDashboardsSvc.copy(dashboard)
       else


### PR DESCRIPTION
Fix an issue when the user has more than 30 companies and the current
company is not returned in the first page.

This is a work around as impac-angular is not too flexible (initially designed for customer view with a small number of companies)
A better fix would be to rework the way `impac-angular` get the necessary data but this is not in scope for now.

A known issue is that the company list on the multi-company dashboard creation modal will only display the first 30 companies.