### PR TITLE
[KAPP-187] Fix org list when switching designer mode

### DIFF
--- a/src/app/services/impac-config/impac-config.coffee
+++ b/src/app/services/impac-config/impac-config.coffee
@@ -80,6 +80,11 @@
       $q.reject(err)
 
   @configureDashboardDesigner = (enabled) ->
+    # When switching from dashboard designer to staff dashboard, we need to clear the ImpacMainSvc cache
+    # as the `dashboard-create` component is not forcing a refresh.
+    # We don't want to force a refresh on this component for performance reason.
+    clearMainSvcCache = _self.dashboardDesigner && !enabled
+
     _self.dashboardDesigner = enabled
 
     $log.info('Configuring dashboard designer', enabled, _self.dashboardDesigner)
@@ -116,6 +121,8 @@
         pdfModeEnabled: !enabled
 
     ImpacTheming.configure(options)
+
+    ImpacMainSvc.loadOrganizations(true) if clearMainSvcCache
 
   @enableDashboardDesigner = ->
     _self.configureDashboardDesigner(true)


### PR DESCRIPTION
Force a refresh when switching from template to staff dashboard.

`ImpacMAinSvc` is [caching the organisations list](https://github.com/maestrano/impac-angular/blob/6ecb128b7dcf55eeeb7ddd9e7d089bcd41d95391/src/services/main/main.svc.coffee#L44).
When loading a dashboard template, Impac is loaded and force a refresh of this list.

When subsequently going to an organisation page, the `dashboard-create` component is [not forcing a reload](https://github.com/maestrano/impac-angular/blob/2a2a5692df7efd908ae6dccd2f7d9bbf14d7428b/src/components/dashboard-create/dashboard-create.component.coffee#L14) which mean we only display the user organisation in the multi company list (in this case, the admin org)

This triggers a refresh when changing from the template mode to the staff dashboard mode. This preserve the benefit of caching when looking consecutively at multiple organisations.